### PR TITLE
Add support for variables, loops and functions with go template

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -16,6 +16,11 @@ type EvaluatorOption func(*VHS)
 // Evaluate takes as input a tape string, an output writer, and an output file
 // and evaluates all the commands within the tape string and produces a GIF.
 func Evaluate(tape string, out io.Writer, opts ...EvaluatorOption) error {
+	tape, err := ExecuteTemplate(tape)
+	if err != nil {
+		return err
+	}
+
 	l := NewLexer(tape)
 	p := NewParser(l)
 

--- a/template.go
+++ b/template.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"html/template"
+	"strings"
+)
+
+// ExecuteTemplate executes the template with the given tape and returns the output.
+func ExecuteTemplate(tape string) (string, error) {
+	parsed, err := template.
+		New("Tape").
+		Funcs(template.FuncMap{
+			"add": func(a, b int) int {
+				return a + b
+			},
+			"repeat": func(s string, n int) string {
+				return strings.Repeat(s, n)
+			},
+		}).
+		Parse(tape)
+
+	if err != nil {
+		return "", err
+	}
+
+	var output strings.Builder
+
+	err = parsed.Execute(&output, nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	return output.String(), nil
+}


### PR DESCRIPTION
Hi charm! I've been using your tool lately and it's awesome! 
One thing I was missing is more programmatic approach.

This PR executes [text/template](https://pkg.go.dev/text/template) before parsing the tape further. That way it's possible to define variables, use loops and anything else go templates offer. I also added 2 basic functions for template's FuncMap such as `repeat` to repeat string N times and `add` to sum numbers. But of course more functions could be added.

Usage Example
```elixir
# We can define 'strings' function in template's FuncMap to create string arrays
{{ $required := strings "echo" "gum" "gh" }}

{{ range $bin := $required  }}
Require {{  $bin  }}
{{ end }}
```

Let me know what you think! 🐳