### PR TITLE
feat: use powershell as default shell on windows>=10 + compile-time optimizations

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
-	"runtime"
 )
 
 // randomPort returns a random port number that is not in use.
@@ -32,12 +31,9 @@ func StartTTY(port int) *exec.Cmd {
 		"-t", "cursorBlink=true",
 		"-t", "customGlyphs=true",
 	}
-	switch runtime.GOOS {
-	case "windows":
-		args = append(args, "cmd.exe")
-	default:
-		args = append(args, "bash", "--login")
-	}
+
+	args = append(args, defaultShellWithArgs()...)
+
 	//nolint:gosec
 	cmd := exec.Command("ttyd", args...)
 	return cmd

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,0 +1,10 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+func defaultShellWithArgs() []string {
+	return []string{
+		"bash", "--login",
+	}
+}

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+// +build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+func defaultShellWithArgs() []string {
+	shell := "cmd"
+	major, _, _ := windows.RtlGetNtVersionNumbers()
+
+	if major >= 10 {
+		shell = "powershell"
+	}
+
+	return []string{
+		shell,
+	}
+}

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -6,14 +6,10 @@ package main
 import "golang.org/x/sys/windows"
 
 func defaultShellWithArgs() []string {
-	shell := "cmd"
 	major, _, _ := windows.RtlGetNtVersionNumbers()
-
 	if major >= 10 {
-		shell = "powershell"
+		return []string{"powershell"}
 	}
 
-	return []string{
-		shell,
-	}
+	return []string{"cmd"}
 }


### PR DESCRIPTION
Using `cmd` instead of `powershell` leads to a strange render:
![cmd](https://user-images.githubusercontent.com/30433331/198969540-7b74f52a-998a-4580-bec4-e6b7fff2c3ff.gif)

I also see no reason to set default shell in runtime.
This pull request fixes this, and leaves the option to use the tool on older versions.
