### PR TITLE
docs(readme): add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Use a package manager:
 brew install charmbracelet/tap/vhs ffmpeg
 brew install ttyd --HEAD
 
+# macOS (via MacPorts)
+sudo port install vhs
+
 # Arch Linux (btw)
 yay -S vhs-bin
 


### PR DESCRIPTION
On macOS, `vhs` can now be installed via MacPorts: https://ports.macports.org/port/vhs/