### PR TITLE
fix: never os.Exit, return error

### DIFF
--- a/command.go
+++ b/command.go
@@ -333,19 +333,8 @@ func getTheme(s string) (Theme, error) {
 	case '{':
 		return getJSONTheme(s)
 	default:
-		return getNamedTheme(s)
+		return findTheme(s)
 	}
-}
-
-func getNamedTheme(s string) (Theme, error) {
-	theme, suggestions, ok := findTheme(s)
-	if !ok && len(suggestions) > 0 {
-		return DefaultTheme, fmt.Errorf("invalid `Set Theme %q`: did you mean %q", s, strings.Join(suggestions, ", "))
-	}
-	if !ok {
-		return DefaultTheme, fmt.Errorf("invalid `Set Theme %q`: theme does not exist", s)
-	}
-	return theme, nil
 }
 
 func getJSONTheme(s string) (Theme, error) {

--- a/main.go
+++ b/main.go
@@ -71,15 +71,20 @@ var (
 		Use:   "themes",
 		Short: "List all the available themes, one per line",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var prefix, suffix string
 			if markdown {
 				fmt.Fprintf(cmd.OutOrStdout(), "# Themes\n\n")
 				prefix, suffix = "* `", "`"
 			}
-			for _, theme := range sortedThemeNames() {
+			themes, err := sortedThemeNames()
+			if err != nil {
+				return err
+			}
+			for _, theme := range themes {
 				fmt.Fprintf(cmd.OutOrStdout(), "%s%s%s\n", prefix, theme, suffix)
 			}
+			return nil
 		},
 	}
 

--- a/themes.go
+++ b/themes.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -20,34 +19,64 @@ var (
 	customThemesBts []byte
 )
 
+// ThemeNotFoundError is returned when a requested theme is not found.
+type ThemeNotFoundError struct {
+	Theme       string
+	Suggestions []string
+}
+
+func (e ThemeNotFoundError) Error() string {
+	if len(e.Suggestions) == 0 {
+		return fmt.Sprintf("invalid `Set Theme %q`: theme does not exist", e.Theme)
+	}
+
+	return fmt.Sprintf("invalid `Set Theme %q`: did you mean %q",
+		e.Theme,
+		strings.Join(e.Suggestions, ", "),
+	)
+}
+
 // sortedThemeNames returns the names of the themes, sorted.
-func sortedThemeNames() []string {
+func sortedThemeNames() ([]string, error) {
 	var keys []string
 	for _, bts := range [][]byte{themesBts, customThemesBts} {
-		for _, theme := range parseThemes(bts) {
+		themes, err := parseThemes(bts)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, theme := range themes {
 			keys = append(keys, theme.Name)
 		}
 	}
 	sort.Slice(keys, func(i, j int) bool {
 		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
 	})
-	return keys
+	return keys, nil
 }
 
 const distance = 2
 
 // findTheme return the given theme, if it exists.
-func findTheme(name string) (Theme, []string, bool) {
+func findTheme(name string) (Theme, error) {
 	for _, bts := range [][]byte{themesBts, customThemesBts} {
-		for _, theme := range parseThemes(bts) {
+		themes, err := parseThemes(bts)
+		if err != nil {
+			return Theme{}, err
+		}
+
+		for _, theme := range themes {
 			if theme.Name == name {
-				return theme, nil, true
+				return theme, nil
 			}
 		}
 	}
 
 	// not found, lets find similar themes!
-	keys := sortedThemeNames()
+	keys, err := sortedThemeNames()
+	if err != nil {
+		return Theme{}, err
+	}
 
 	suggestions := []string{}
 	lname := strings.ToLower(name)
@@ -60,14 +89,13 @@ func findTheme(name string) (Theme, []string, bool) {
 			suggestions = append(suggestions, theme)
 		}
 	}
-	return Theme{}, suggestions, false
+	return Theme{}, ThemeNotFoundError{name, suggestions}
 }
 
-func parseThemes(bts []byte) []Theme {
+func parseThemes(bts []byte) ([]Theme, error) {
 	var themes []Theme
 	if err := json.Unmarshal(bts, &themes); err != nil {
-		fmt.Fprintf(os.Stderr, "could not load themes.json: %s\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("could not load themes.json: %w", err)
 	}
-	return themes
+	return themes, nil
 }

--- a/themes_test.go
+++ b/themes_test.go
@@ -1,9 +1,14 @@
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestFindAllThemes(t *testing.T) {
-	themes := sortedThemeNames()
+	themes, err := sortedThemeNames()
+	if err != nil {
+		t.Fatal(err)
+	}
 	expect := 295
 	if l := len(themes); l != expect {
 		t.Errorf("expected to load %d themes, got %d", expect, l)
@@ -11,14 +16,20 @@ func TestFindAllThemes(t *testing.T) {
 }
 
 func TestFindTheme(t *testing.T) {
-	theme, suggestions, ok := findTheme("caTppuccin ltt")
-	if ok {
+	theme, err := findTheme("Catppuccin Latte")
+	if err != nil {
+		t.Error(err)
+	}
+
+	theme, err = findTheme("caTppuccin ltt")
+	te, ok := err.(ThemeNotFoundError)
+	if !ok {
 		t.Fatal("expected to not be found:", theme)
 	}
-	if len(suggestions) != 1 {
-		t.Fatal("expected 1 suggestions, got:", suggestions)
+	if len(te.Suggestions) != 1 {
+		t.Fatal("expected 1 suggestions, got:", te.Suggestions)
 	}
-	if sg := suggestions[0]; sg != "Catppuccin Latte" {
-		t.Fatal("wrong suggestion:", suggestions[0])
+	if sg := te.Suggestions[0]; sg != "Catppuccin Latte" {
+		t.Fatal("wrong suggestion:", te.Suggestions[0])
 	}
 }


### PR DESCRIPTION
This is a bit of an edge case, as the themes.json file is embedded and technically should never fail to parse, but even then it's probably a bad idea to tear down the entire process without any deferred cleanups.