### PR TITLE
enable sixel on ttyd (note: this does not make them appear in the GIF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 **/*.gif filter=lfs diff=lfs merge=lfs -text
 **/*.mp4 filter=lfs diff=lfs merge=lfs -text
 **/*.webm filter=lfs diff=lfs merge=lfs -text
+**/*.png filter=lfs diff=lfs merge=lfs -text
 themes*.json linguist-generated
 THEMES.md linguist-generated

--- a/examples/images/bubbletea.png
+++ b/examples/images/bubbletea.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad032a6282e068e1953373736543c3491b654ddd9c1732939f6a44e25dd2d5b
+size 9577

--- a/examples/images/glamour.png
+++ b/examples/images/glamour.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21c11be4f5197ba5cc7a54ae75b8ed6593f1ec653c3011c6d52be87a67f5fbc7
+size 12181

--- a/examples/images/gum.png
+++ b/examples/images/gum.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:911b1a9889e1907aba51b5be57dc5424689c1478fa500721b89e447a19adac72
+size 17040

--- a/examples/images/harmonica.png
+++ b/examples/images/harmonica.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c260e565d4dd795b83f48311984f26a251774aa5cf4af0f0fce19871cd1644e
+size 13884

--- a/examples/images/images.tape
+++ b/examples/images/images.tape
@@ -1,0 +1,5 @@
+Output images.gif
+
+Type "lsix *.png"
+Enter
+Sleep 3s

--- a/examples/images/lipgloss.png
+++ b/examples/images/lipgloss.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:945905c3fbf4a77ee724bdc48cb9fc25d2bb551ad48e9b33f8092e53cef47671
+size 19308

--- a/examples/images/melt.png
+++ b/examples/images/melt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:593f88436cc66f5bdc2112f4b84f852ecf4b1fc24c9ad77f6e417885b0292dd1
+size 8553

--- a/examples/images/skate.png
+++ b/examples/images/skate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b47bf0fb23e2344b2680d0c9e6eab9360c2cc2aa0b2655a8ac11dbfd6515db6
+size 18528

--- a/examples/images/soft-serve.png
+++ b/examples/images/soft-serve.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f74fd8fe4bcdbdf21a5dcd0539688045af8cc0838deaff0bd6111f32a28638a
+size 11709

--- a/examples/images/wish.png
+++ b/examples/images/wish.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:538eb5ef9ad541c241f2b19caa4be8a7c3d916f96b82377602b65b5fa7632562
+size 11555

--- a/tty.go
+++ b/tty.go
@@ -29,6 +29,7 @@ func StartTTY(port int) *exec.Cmd {
 		"-t", "rendererType=canvas",
 		"-t", "disableResizeOverlay=true",
 		"-t", "cursorBlink=true",
+		"-t", "enableSixel=true",
 		"-t", "customGlyphs=true",
 	}
 


### PR DESCRIPTION
Enable sixel on ttyd (note: this commit does not make the images appear in the GIF)

This PR allows ttyd / xterm to support sixel but does not yet solve VHS support
(yet).
This is because the images are rendered on a separate canvas that we'll need to
capture in order to support.
