### PR TITLE
fix(examples): output file name

### DIFF
--- a/examples/settings/set-shell-bash.gif
+++ b/examples/settings/set-shell-bash.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d80b2b06b9fe1c9fccfea85ad9f4cdf27297f5fb13889a4d3499b66f684b37c3
+size 17844

--- a/examples/settings/set-shell-bash.tape
+++ b/examples/settings/set-shell-bash.tape
@@ -1,4 +1,4 @@
-Output examples/settings/set-shell-zsh.gif
+Output examples/settings/set-shell-bash.gif
 
 Set FontSize 38
 Set Height 225

--- a/examples/settings/set-shell-zsh.gif
+++ b/examples/settings/set-shell-zsh.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5109518a0207860ba3be98d12e0442c3ca69acd9b8871833eb941f0ca1337342
-size 16495
+oid sha256:d8160a9acead3d2f9a41ed72353a0acaaea69fd3d4cfc3dd9805f40be1f9cddf
+size 24784


### PR DESCRIPTION
bash examples overwrites zsh