### PR TITLE
fix(pwsh): add powershell shell

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -5,7 +5,8 @@ const (
 	bash       = "bash"
 	cmdexe     = "cmd"
 	fish       = "fish"
-	powershell = "pwsh"
+	powershell = "powershell"
+	pwsh       = "pwsh"
 	zsh        = "zsh"
 )
 
@@ -30,6 +31,10 @@ var Shells = map[string]Shell{
 		Command: `clear; fish --login --private -C 'function fish_greeting; end' -C '%s'`,
 	},
 	powershell: {
+		Prompt:  "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+		Command: ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
+	},
+	pwsh: {
 		Prompt:  "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
 		Command: ` clear; pwsh -Login -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
 	},

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -3,15 +3,23 @@
 
 package main
 
-import "golang.org/x/sys/windows"
+import (
+	"os/exec"
 
-const defaultShell = powershell
+	"golang.org/x/sys/windows"
+)
+
+var defaultShell = cmdexe
 
 func defaultShellWithArgs() []string {
 	major, _, _ := windows.RtlGetNtVersionNumbers()
 	if major >= 10 {
-		return []string{"powershell"}
+		if _, err := exec.LookPath("pwsh"); err == nil {
+			defaultShell = pwsh
+		} else {
+			defaultShell = powershell
+		}
 	}
 
-	return []string{"cmd"}
+	return []string{defaultShell}
 }


### PR DESCRIPTION
pwsh is only added on newer versions of PowerShell which might not be pre-installed in Windows 10