### PR TITLE
Cross-platform fixes + new features

### DIFF
--- a/command.go
+++ b/command.go
@@ -254,7 +254,7 @@ func ExecuteSetWidth(c Command, v *VHS) {
 // ExecuteSetShell applies the shell on the vhs.
 func ExecuteSetShell(c Command, v *VHS) {
 	if s, ok := Shells[c.Args]; ok {
-		v.Options.Shell = s
+		v.Options.Shell = s()
 	} else {
 		v.Options.Shell.Prompt = ""
 		v.Options.Shell.Command = c.Args

--- a/shell.go
+++ b/shell.go
@@ -2,44 +2,18 @@ package main
 
 // Supported shells of VHS
 const (
-	bash       = "bash"
-	cmdexe     = "cmd"
-	fish       = "fish"
-	powershell = "powershell"
-	pwsh       = "pwsh"
-	zsh        = "zsh"
+	bash   = "bash"
+	cmdexe = "cmd"
+	fish   = "fish"
+	pwsh   = "pwsh"
+	zsh    = "zsh"
 )
 
 // Shell is a type that contains a prompt and the command to set up the shell.
 type Shell struct {
-	Prompt  string
-	Command string
+	EntryPoint string
+	Prompt     string
+	Command    string
 }
 
-// Shells contains a mapping from shell names to their Shell struct.
-var Shells = map[string]Shell{
-	bash: {
-		Prompt:  "\\[\\e[38;2;90;86;224m\\]> \\[\\e[0m\\]",
-		Command: ` set +o history; unset PROMPT_COMMAND; export PS1="%s"; clear;`,
-	},
-	zsh: {
-		Prompt:  `%F{#5B56E0}> %F{reset_color}`,
-		Command: ` clear; zsh --login --histnostore; unsetopt PROMPT_SP; unset PROMPT; export PS1="%s"; clear`,
-	},
-	fish: {
-		Prompt:  `function fish_prompt; echo -e "$(set_color 5B56E0)> $(set_color normal)"; end`,
-		Command: `clear; fish --login --private -C 'function fish_greeting; end' -C '%s'`,
-	},
-	powershell: {
-		Prompt:  "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
-		Command: ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
-	},
-	pwsh: {
-		Prompt:  "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
-		Command: ` clear; pwsh -Login -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
-	},
-	cmdexe: {
-		Prompt:  "$g",
-		Command: ` cls && set prompt=%s && cls`,
-	},
-}
+type LazyShell func() Shell

--- a/shell_unix.go
+++ b/shell_unix.go
@@ -1,0 +1,37 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+var Shells = map[string]LazyShell{
+	bash: func() Shell {
+		return Shell{
+			EntryPoint: "bash --login",
+			Prompt:     "\\[\\e[38;2;90;86;224m\\]> \\[\\e[0m\\]",
+			Command:    ` set +o history; unset PROMPT_COMMAND; export PS1="%s"; clear;`,
+		}
+	},
+	zsh: func() Shell {
+		return Shell{
+			EntryPoint: "bash --login",
+			Prompt:     `%F{#5B56E0}> %F{reset_color}`,
+			Command:    ` clear; zsh --login --histnostore; unsetopt PROMPT_SP; unset PROMPT; export PS1="%s"; clear`,
+		}
+	},
+	fish: func() Shell {
+		return Shell{
+			EntryPoint: "bash --login",
+			Prompt:     `function fish_prompt; echo -e "$(set_color 5B56E0)> $(set_color normal)"; end`,
+			Command:    `clear; fish --login --private -C 'function fish_greeting; end' -C '%s'`,
+		}
+	},
+	pwsh: func() Shell {
+		return Shell{
+			EntryPoint: "bash --login",
+			Prompt:     "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+			Command:    ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
+		}
+	},
+}
+
+var defaultShell = bash

--- a/shell_unix.go
+++ b/shell_unix.go
@@ -28,7 +28,7 @@ var Shells = map[string]LazyShell{
 	pwsh: func() Shell {
 		return Shell{
 			EntryPoint: "bash --login",
-			Prompt:     "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+			Prompt:     "Function prompt {Write-Host \\\"> \\\" -ForegroundColor Blue -NoNewLine; return \\\"`0\\\" }",
 			Command:    ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
 		}
 	},

--- a/shell_windows.go
+++ b/shell_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+package main
+
+import "os/exec"
+
+var Shells = map[string]LazyShell{
+	cmdexe: func() Shell {
+		return Shell{
+			EntryPoint: "cmd",
+			Prompt:     "$g",
+			Command:    ` cls && set prompt=%s && cls`,
+		}
+	},
+	pwsh: func() Shell {
+		if _, err := exec.LookPath("pwsh"); err == nil {
+			return Shell{
+				EntryPoint: "powershell",
+				Prompt:     "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+				Command:    ` clear; pwsh -Login -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
+			}
+		}
+
+		return Shell{
+			EntryPoint: "powershell",
+			Prompt:     "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+			Command:    ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
+		}
+	},
+}
+
+var defaultShell = cmdexe

--- a/shell_windows.go
+++ b/shell_windows.go
@@ -17,14 +17,14 @@ var Shells = map[string]LazyShell{
 		if _, err := exec.LookPath("pwsh"); err == nil {
 			return Shell{
 				EntryPoint: "powershell",
-				Prompt:     "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+				Prompt:     "Function prompt {Write-Host \\\"> \\\" -ForegroundColor Blue -NoNewLine; return \\\"`0\\\" }",
 				Command:    ` clear; pwsh -Login -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
 			}
 		}
 
 		return Shell{
 			EntryPoint: "powershell",
-			Prompt:     "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+			Prompt:     "Function prompt {Write-Host \\\"> \\\" -ForegroundColor Blue -NoNewLine; return \\\"`0\\\" }",
 			Command:    ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
 		}
 	},

--- a/tty.go
+++ b/tty.go
@@ -33,7 +33,7 @@ func StartTTY(port int) *exec.Cmd {
 		"-t", "customGlyphs=true",
 	}
 
-	args = append(args, defaultShellWithArgs()...)
+	args = append(args, defaultEntryPoint()...)
 
 	//nolint:gosec
 	cmd := exec.Command("ttyd", args...)

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -3,10 +3,6 @@
 
 package main
 
-const defaultShell = bash
-
-func defaultShellWithArgs() []string {
-	return []string{
-		"bash", "--login",
-	}
+func defaultEntryPoint() []string {
+	return []string{"bash", "--login"}
 }

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -3,23 +3,6 @@
 
 package main
 
-import (
-	"os/exec"
-
-	"golang.org/x/sys/windows"
-)
-
-var defaultShell = cmdexe
-
-func defaultShellWithArgs() []string {
-	major, _, _ := windows.RtlGetNtVersionNumbers()
-	if major >= 10 {
-		if _, err := exec.LookPath("pwsh"); err == nil {
-			defaultShell = pwsh
-		} else {
-			defaultShell = powershell
-		}
-	}
-
-	return []string{defaultShell}
+func defaultEntryPoint() []string {
+	return []string{"cmd"}
 }

--- a/vhs.go
+++ b/vhs.go
@@ -106,6 +106,7 @@ func New() VHS {
 }
 
 const magicText = "charmcharm"
+const commandExecutionWaitTime = 3 * time.Second
 
 // Setup sets up the VHS instance and performs the necessary actions to reflect
 // the options that are default and set by the user.
@@ -160,6 +161,10 @@ func (vhs *VHS) Setup() {
 
 	_ = os.RemoveAll(vhs.Options.Video.Input)
 	_ = os.MkdirAll(vhs.Options.Video.Input, os.ModePerm)
+
+	// FIXME: Since we have not yet figured out how to make sure that all the
+	// commands have been executed, we will give some time for this to happen for sure.
+	time.Sleep(commandExecutionWaitTime)
 }
 
 const cleanupWaitTime = 100 * time.Millisecond


### PR DESCRIPTION
Hey guys, I have a lot of things for you.
To begin with, the tool has big problems with cross-platform and not only, so I suggest you look at my solutions to these problems.

## Entry Points Introduction
Allows to select the environment in which subsequent commands will work.
Something like a replacement for 6466fa95686a2e3c245bfbe8245741221660ba63 but with more features.

## "Lazy Shells" Introduction
_From the point of view of the language, these are just functions that return `Shell` structure._

This thing allows you to handle additional conditions, which for example helps to solve compatibility problems or detect if the user does not have a specific shell.

Example:
https://github.com/charmbracelet/vhs/blob/3797c980d7c84875fd34193b5c44865c3d9d022f/shell_windows.go#L16-L29

_Here we determine which version of PowerShell is available and, depending on this, we call the necessary parameters._

## Other things
### Remove useless work (due to `feat: Set Shell` and features above)
See f525522172e0d9590943f0247ba4bcd2553b6a26.
Previously, it was necessary to solve the problem of working on Windows, as well as fix the output.
And now with the new features, it's just useless.

### Splitting the shell list into "Windows compatible" and "Unix compatible".
See [shell_windows.go](https://github.com/charmbracelet/vhs/blob/3797c980d7c84875fd34193b5c44865c3d9d022f/shell_windows.go) and [shell_unix.go](https://github.com/charmbracelet/vhs/blob/3797c980d7c84875fd34193b5c44865c3d9d022f/shell_unix.go)

### Fix incorrect powershell output (72d81d6b52a375d45dda97c26625f7b8335bd220)

Tape:
```elixir
# Where should we write the GIF?
Output demo.gif
Set Shell pwsh

# Set up a 1200x600 terminal with 46px font.
Set FontSize 46
Set Width 1200
Set Height 600

# Type a command in the terminal.
Type "echo 'Welcome to VHS!'"

# Pause for dramatic effect...
Sleep 500ms

# Run the command by pressing enter.
Enter

# Admire the output for a bit.
Sleep 5s
```

Before:
![frame223](https://user-images.githubusercontent.com/30433331/200130843-dd65e81b-80d3-451c-afd1-30e095be1f5b.png)

After:
![frame221](https://user-images.githubusercontent.com/30433331/200130890-7f3ae049-8bc5-4b7b-bc62-7f0bfa959b25.png)

### Fix #39 (e8d5abf3beb889782ad3d66e810b9f0a75b7f3a8)
This problem arises due to the fact that we start recording before our "prepare" commands are executed. The next solution is more of a crutch, which in some cases may not help, but still better than nothing.

https://github.com/charmbracelet/vhs/blob/e8d5abf3beb889782ad3d66e810b9f0a75b7f3a8/vhs.go#L165-L167

First frame before:
![frame1](https://user-images.githubusercontent.com/30433331/200132011-60a74824-e093-46bf-87ce-980853f6f6f4.png)

First frame after:
![frame1](https://user-images.githubusercontent.com/30433331/200132025-64d56178-cb9b-4f7f-bbe3-ef3149abac80.png)


###  Remove unlogical `pwsh != powershell` from b0c663c9bc8065d73412a442d8672f4fe59cffa0
Due to "Lazy Shells" now it's possible.

Before:
```elixir
# What to use?
Set Shell pwsh
# or
Set Shell powershell

# What a difference? Idk...
# HELP!
```

After:
```elixir
# 😎
Set Shell pwsh
```

### ~Another crutch~ Correction of possible errors related to the fact that logging into the shell may be too long
https://github.com/charmbracelet/vhs/blob/3797c980d7c84875fd34193b5c44865c3d9d022f/vhs.go#L132-L142

_At first it was one of the implementations of new features, but then I realized that it solves more things._

---

In the end, I want to say that I'm new to golang, so there may not be completely rational things here, so if anything, leave your reviews so that I can improve and learn new things)

Thank you!
Have a nice day!
