### PR TITLE
GitHub syntax highlighting for .tape files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 **/*.png filter=lfs diff=lfs merge=lfs -text
 themes*.json linguist-generated
 THEMES.md linguist-generated
+*.tape linguist-language=Elixir


### PR DESCRIPTION
Github's highlighting is powered by [github/linguist](https://github.com/github/linguist/blob/master/CONTRIBUTING.md#adding-a-language), and they allow to submit new languages if they're popular enough (used in >200 repos).

Until GItHub supports it, throwing this in a repo's .gitattributes will highlight it by pretending it's Elixir (as you do in the README):

```gitattributes
*.tape linguist-language=Elixir
```