### PR TITLE
fix: powershell prompt

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -31,11 +31,11 @@ var Shells = map[string]Shell{
 		Command: `clear; fish --login --private -C 'function fish_greeting; end' -C '%s'`,
 	},
 	powershell: {
-		Prompt:  "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+		Prompt:  "Function prompt {Write-Host \\\"> \\\" -ForegroundColor Blue -NoNewLine; return \\\"`0\\\" }",
 		Command: ` clear; powershell -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
 	},
 	pwsh: {
-		Prompt:  "Function prompt {Write-Host \"> \" -ForegroundColor Blue -NoNewLine; return \"`0\" }",
+		Prompt:  "Function prompt {Write-Host \\\"> \\\" -ForegroundColor Blue -NoNewLine; return \\\"`0\\\" }",
 		Command: ` clear; pwsh -Login -NoLogo -NoExit -Command 'Set-PSReadLineOption -HistorySaveStyle SaveNothing; %s'`,
 	},
 	cmdexe: {


### PR DESCRIPTION
Properly escape powershell/pwsh prompts

Fixes: b0c663c9bc80 ("fix(pwsh): add powershell shell")