### PR TITLE
feat: allow --output to override output location

### DIFF
--- a/video.go
+++ b/video.go
@@ -84,7 +84,7 @@ func MakeGIF(opts VideoOptions) *exec.Cmd {
 		return nil
 	}
 
-	fmt.Println("Creating GIF...")
+	fmt.Printf("Creating %s...\n", opts.Output.GIF)
 
 	//nolint:gosec
 	return exec.Command(
@@ -116,7 +116,7 @@ func MakeWebM(opts VideoOptions) *exec.Cmd {
 		return nil
 	}
 
-	fmt.Println("Creating WebM...")
+	fmt.Printf("Creating %s...\n", opts.Output.WebM)
 
 	//nolint:gosec
 	return exec.Command(
@@ -151,7 +151,7 @@ func MakeMP4(opts VideoOptions) *exec.Cmd {
 		return nil
 	}
 
-	fmt.Println("Creating MP4...")
+	fmt.Printf("Creating %s...\n", opts.Output.MP4)
 
 	//nolint:gosec
 	return exec.Command(


### PR DESCRIPTION
Allow `Output` location to be overridden by CLI flags:

Specify multiple outputs in the same flag.

```bash
vhs demo.tape --output out.gif,out.webm
```
  
Pass multiple flags (with shorthand):
  
```bash
vhs demo.tape -o out.gif -o out.webm
```

Note: this will override any `Output` commands set in the tape file.