### PR TITLE
feat: env var to optionally set go-rod no-sandbox

### DIFF
--- a/vhs.go
+++ b/vhs.go
@@ -89,7 +89,8 @@ func New() VHS {
 
 	opts := DefaultVHSOptions()
 	path, _ := launcher.LookPath()
-	u := launcher.New().Leakless(false).Bin(path).MustLaunch()
+	enableNoSandbox := os.Getenv("VHS_NO_SANDBOX") != ""
+	u := launcher.New().Leakless(false).Bin(path).NoSandbox(enableNoSandbox).MustLaunch()
 	browser := rod.New().ControlURL(u).MustConnect()
 	page := browser.MustPage(fmt.Sprintf("http://localhost:%d", port))
 


### PR DESCRIPTION
This PR adds an environment variable to enable [go-rod's no-sandbox option](https://github.com/go-rod/rod/blob/611fbdd4e29fedc18478586057ea293847da317d/lib/launcher/launcher.go#L228).

This was suggested by the go-rod maintainer in the following issue: https://github.com/charmbracelet/vhs/issues/45#issuecomment-1296121300

I know the issue is closed but I couldn't find any other way to integrate vhs in a docker build process like for example with the following Dockerfile:
```Dockerfile
# syntax=docker/dockerfile:1.4

FROM ghcr.io/charmbracelet/vhs
COPY <<EOF hello.tape
    Output hello.gif
    Type "echo test"
    Sleep 500ms
    Enter
    Sleep 1s
EOF
RUN vhs hello.tape
```

When running with this patch it works when setting the newly added environment variable:
```Dockerfile
# syntax=docker/dockerfile:1.4

FROM ghcr.io/brumhard/vhs:0.0.4
ENV VHS_NO_SANDBOX="true"
COPY <<EOF hello.tape
    Output hello.gif
    Type "echo test"
    Sleep 500ms
    Enter
    Sleep 1s
EOF
RUN vhs hello.tape
```