### PR TITLE
fix: zsh, bash and fish: do not use user/system rcs

### DIFF
--- a/examples/settings/set-shell-bash.gif
+++ b/examples/settings/set-shell-bash.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d80b2b06b9fe1c9fccfea85ad9f4cdf27297f5fb13889a4d3499b66f684b37c3
-size 17844
+oid sha256:c1ea960843c9a998739eb929ed32f2d4530b1c3e7aa048c20cc8f3aef457fbf9
+size 14841

--- a/examples/settings/set-shell-fish.gif
+++ b/examples/settings/set-shell-fish.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027c728bf1070907e945f1281d8029ace67219ac1c015c7a67da2e72d471ff3a
+size 40426

--- a/examples/settings/set-shell-zsh.gif
+++ b/examples/settings/set-shell-zsh.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8160a9acead3d2f9a41ed72353a0acaaea69fd3d4cfc3dd9805f40be1f9cddf
-size 24784
+oid sha256:f75e287f7a6ad04d67d391e1d81032332ea5b988f6b5f6f6c058f88fd22ca6eb
+size 14095

--- a/shell.go
+++ b/shell.go
@@ -20,15 +20,15 @@ type Shell struct {
 var Shells = map[string]Shell{
 	bash: {
 		Prompt:  "\\[\\e[38;2;90;86;224m\\]> \\[\\e[0m\\]",
-		Command: ` set +o history; unset PROMPT_COMMAND; export PS1="%s"; clear;`,
+		Command: ` clear; PS1="%s" bash --login --norc --noprofile; set +o history; clear;`,
 	},
 	zsh: {
 		Prompt:  `%F{#5B56E0}> %F{reset_color}`,
-		Command: ` clear; zsh --login --histnostore; unsetopt PROMPT_SP; unset PROMPT; export PS1="%s"; clear`,
+		Command: ` clear; PROMPT="%s" zsh --login --histnostore --no-rcs; clear`,
 	},
 	fish: {
 		Prompt:  `function fish_prompt; echo -e "$(set_color 5B56E0)> $(set_color normal)"; end`,
-		Command: `clear; fish --login --private -C 'function fish_greeting; end' -C '%s'`,
+		Command: ` clear; fish --login --no-config --private -C 'function fish_greeting; end' -C '%s'`,
 	},
 	powershell: {
 		Prompt:  "Function prompt {Write-Host \\\"> \\\" -ForegroundColor Blue -NoNewLine; return \\\"`0\\\" }",


### PR DESCRIPTION
assuming that probably in https://github.com/charmbracelet/vhs/issues/39 the problem is zsh is using the user/rc config, this should prevent that.

also did the same for bash and fish.