### PR TITLE
fix: running vhs without arguments or stdin should display help

### DIFF
--- a/examples/welcome.gif
+++ b/examples/welcome.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7960f2fb1d41e44318fc497abd7a00d3ba0feae31a94ba3b17b195b6ed8029a
-size 261631
+oid sha256:de69582e8664e1278e48e7bdf7f40e166ae2a751b0173096990d4ff14329fca6
+size 309784

--- a/main.go
+++ b/main.go
@@ -56,6 +56,13 @@ var (
 					return err
 				}
 				fmt.Println(GrayStyle.Render("File: " + args[0]))
+			} else {
+				stat, _ := os.Stdin.Stat()
+				if (stat.Mode() & os.ModeCharDevice) != 0 {
+					// The user ran vhs without any arguments or stdin.
+					// Print the usage.
+					return cmd.Help()
+				}
 			}
 
 			input, err := io.ReadAll(in)


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/vhs/issues/207

Running `vhs` without arguments should display help instead of waiting for `stdin`.