### PR TITLE
ttyd listens on loopback interface only

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -26,6 +26,7 @@ func randomPort() int {
 func StartTTY(port int) *exec.Cmd {
 	args := []string{
 		fmt.Sprintf("--port=%d", port),
+		"--interface", "127.0.0.1",
 		"-t", "rendererType=canvas",
 		"-t", "disableResizeOverlay=true",
 		"-t", "cursorBlink=true",


### PR DESCRIPTION
## What does this change do?

Fix issue #226 by configuring `ttyd` to only listen on `127.0.0.1`

## What testing did I do?

Using the Dockerfile I built my own image with a `vhs` binary built from my branch.

I could successfully create a gif from a tape file:

```
➜  vhs git:(ttyd-localhost-only) ✗ docker run --rm -v $PWD:/vhs c06c63cefe39 demo.tape
File: demo.tape
Host your GIF on vhs.charm.sh: vhs publish <file>.gif
Output .gif demo.gif
Set FontSize 46
Set Width 1200
Set Height 600
Type echo 'Welcome to VHS!'
Sleep 500ms
Enter 1
Sleep 5s
Creating demo.gif...
```

I could also create a gif using `vhs serve`:

```
➜  tapes git:(ttyd-localhost-only) ✗ docker run --rm -p 1976:1976 -v $PWD:/vhs c06c63cefe39 serve
2023/02/14 21:59:26 Starting SSH server on 0.0.0.0:1976
2023/02/14 21:59:26 Starting server with GID: 1976, UID: 1976
2023/02/14 21:59:46 rcw5 connect 172.17.0.1:62870 false []  0 0
Creating /tmp/vhs-947779410.gif...
2023/02/14 22:00:02 172.17.0.1:62870 disconnect 15.332532382s
^C2023/02/14 22:04:20 Stopping SSH server
ssh: Server closed
```

```
➜  tapes git:(ttyd-localhost-only) ✗ ssh localhost -p 1976 < demo.tape > demo.gif
Output .gif demo.gif
Set FontSize 46
Set Width 1200
Set Height 600
Type echo 'Welcome to VHS!'
Sleep 500ms
Enter 1
Sleep 5s
```

Thanks for the great tool!