### PR TITLE
refactor: unify publish instructions

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,6 @@ var (
 					publishShareInstructions(url)
 				}
 
-				fmt.Println(URLStyle.Render(url))
 				if isatty.IsTerminal(os.Stdout.Fd()) {
 					fmt.Println()
 				}

--- a/publish.go
+++ b/publish.go
@@ -141,7 +141,7 @@ func publishShareInstructions(url string) {
 	fmt.Println(CommandStyle.Render("  <a ") + CommandStyle.Render("href=") + URLStyle.Render(`"https://vhs.charm.sh"`) + CommandStyle.Render(">"))
 	fmt.Println(CommandStyle.Render("    <img ") + CommandStyle.Render("src=") + URLStyle.Render(`"https://stuff.charm.sh/vhs/badge.svg"`) + CommandStyle.Render(">"))
 	fmt.Println(CommandStyle.Render("  </a>"))
-	fmt.Println(GrayStyle.Render("\n  Or link to it:"))
+	fmt.Println(GrayStyle.Render("\n  Or link to it: " + URLStyle.Render(`"`+url+`"`)))
 	fmt.Printf("  ")
 }
 


### PR DESCRIPTION
Hey I've done a little refactor in the way publish instructions are displayed.

While I was working on this #222 I noticed an error with `--quiet` flag. (See attached imaged)
The `publishShareInstructions` function was not printing last link, with this change we have a better encapsulation.

P.D: Right now this is working fine and is not a problem. However I could be a problem when we'll merge the pull request mentioned above.

![quiet-flag-missing-link](https://user-images.githubusercontent.com/43180519/221437698-00058d09-3b4b-424c-a321-8dbc887efb23.png)
