### PR TITLE
fix: split start into new function

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -22,8 +22,8 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 		return []error{InvalidSyntaxError{errs}}
 	}
 
-	v, err := New()
-	if err != nil {
+	v := New()
+	if err := v.Start(); err != nil {
 		return []error{err}
 	}
 	defer func() { _ = v.close() }()

--- a/tty.go
+++ b/tty.go
@@ -22,8 +22,8 @@ func randomPort() int {
 	return addr.Addr().(*net.TCPAddr).Port
 }
 
-// StartTTY starts the ttyd process on the given port.
-func StartTTY(port int) *exec.Cmd {
+// buildTtyCmd starts the ttyd process on the given port.
+func buildTtyCmd(port int) *exec.Cmd {
 	args := []string{
 		fmt.Sprintf("--port=%d", port),
 		"--interface", "127.0.0.1",
@@ -37,6 +37,5 @@ func StartTTY(port int) *exec.Cmd {
 	args = append(args, defaultShellWithArgs()...)
 
 	//nolint:gosec
-	cmd := exec.Command("ttyd", args...)
-	return cmd
+	return exec.Command("ttyd", args...)
 }

--- a/tty.go
+++ b/tty.go
@@ -22,7 +22,7 @@ func randomPort() int {
 	return addr.Addr().(*net.TCPAddr).Port
 }
 
-// buildTtyCmd starts the ttyd process on the given port.
+// buildTtyCmd builds the ttyd exec.Command on the given port.
 func buildTtyCmd(port int) *exec.Cmd {
 	args := []string{
 		fmt.Sprintf("--port=%d", port),

--- a/vhs.go
+++ b/vhs.go
@@ -94,6 +94,7 @@ func New() VHS {
 	}
 }
 
+// Start starts ttyd, browser and everything else needed to create the gif.
 func (vhs *VHS) Start() error {
 	vhs.mutex.Lock()
 	defer vhs.mutex.Unlock()

--- a/vhs.go
+++ b/vhs.go
@@ -27,6 +27,7 @@ type VHS struct {
 	TextCanvas   *rod.Element
 	CursorCanvas *rod.Element
 	mutex        *sync.Mutex
+	started      bool
 	recording    bool
 	tty          *exec.Cmd
 	totalFrames  int
@@ -83,40 +84,47 @@ func DefaultVHSOptions() Options {
 }
 
 // New sets up ttyd and go-rod for recording frames.
-func New() (VHS, error) {
-	port := randomPort()
-	tty := StartTTY(port)
-	if err := tty.Start(); err != nil {
-		return VHS{}, fmt.Errorf("could not start ttyd: %w", err)
+func New() VHS {
+	mu := &sync.Mutex{}
+	opts := DefaultVHSOptions()
+	return VHS{
+		Options:   &opts,
+		recording: true,
+		mutex:     mu,
+	}
+}
+
+func (vhs *VHS) Start() error {
+	vhs.mutex.Lock()
+	defer vhs.mutex.Unlock()
+
+	if vhs.started {
+		return fmt.Errorf("vhs is already started")
 	}
 
-	opts := DefaultVHSOptions()
-	path, found := launcher.LookPath()
-	if !found {
-		return VHS{}, fmt.Errorf("browser not available in path")
+	port := randomPort()
+	vhs.tty = buildTtyCmd(port)
+	if err := vhs.tty.Start(); err != nil {
+		return fmt.Errorf("could not start tty: %w", err)
 	}
+
+	path, _ := launcher.LookPath()
 	enableNoSandbox := os.Getenv("VHS_NO_SANDBOX") != ""
 	u, err := launcher.New().Leakless(false).Bin(path).NoSandbox(enableNoSandbox).Launch()
 	if err != nil {
-		return VHS{}, fmt.Errorf("could not launch browser: %w", err)
+		return fmt.Errorf("could not launch browser: %w", err)
 	}
 	browser := rod.New().ControlURL(u).MustConnect()
 	page, err := browser.Page(proto.TargetCreateTarget{URL: fmt.Sprintf("http://localhost:%d", port)})
 	if err != nil {
-		return VHS{}, fmt.Errorf("could not open ttyd: %w", err)
+		return fmt.Errorf("could not open ttyd: %w", err)
 	}
 
-	mu := &sync.Mutex{}
-
-	return VHS{
-		Options:   &opts,
-		Page:      page,
-		browser:   browser,
-		tty:       tty,
-		recording: true,
-		mutex:     mu,
-		close:     browser.Close,
-	}, nil
+	vhs.browser = browser
+	vhs.Page = page
+	vhs.close = vhs.browser.Close
+	vhs.started = true
+	return nil
 }
 
 // Setup sets up the VHS instance and performs the necessary actions to reflect


### PR DESCRIPTION
- moved the startup code to a `start` function
- `launcher.Lookpath` is ok to return empty, rod downloads the browser if `bin` is empty
- `StartTTYD` did not start `ttyd`
- do not eat `ttyd` startup errors