### PR TITLE
fix: ttyd --once

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -32,6 +32,7 @@ func buildTtyCmd(port int) *exec.Cmd {
 		"-t", "cursorBlink=true",
 		"-t", "enableSixel=true",
 		"-t", "customGlyphs=true",
+		"--once", // will allow one connection and exit
 	}
 
 	args = append(args, defaultShellWithArgs()...)


### PR DESCRIPTION
From the help:

>     -o, --once              Accept only one client and exit on disconnection

This might be useful if, for example, VHS gets killed for reason and can't clean up after itself, this will guarantee that the ttyd session is also finished, so no one can connect to a dangling ttyd afterwards.