### PR TITLE
add `nushell` to the list of supported shells

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -5,6 +5,7 @@ const (
 	bash       = "bash"
 	cmdexe     = "cmd"
 	fish       = "fish"
+	nushell    = "nushell"
 	powershell = "powershell"
 	pwsh       = "pwsh"
 	zsh        = "zsh"
@@ -60,5 +61,8 @@ var Shells = map[string]Shell{
 	},
 	cmdexe: {
 		Command: []string{"cmd.exe", "/k", "prompt=^> "},
+	},
+	nushell: {
+		Command: []string{"nu", "--interactive"},
 	},
 }

--- a/shell.go
+++ b/shell.go
@@ -5,7 +5,7 @@ const (
 	bash       = "bash"
 	cmdexe     = "cmd"
 	fish       = "fish"
-	nushell    = "nushell"
+	nushell    = "nu"
 	powershell = "powershell"
 	pwsh       = "pwsh"
 	zsh        = "zsh"


### PR DESCRIPTION
hello guys :wave: :yum: 

i'm a [`nushell`](https://www.nushell.sh) user and i'm trying to record a session for the shell
```bash
'
Output out.gif

Set Shell nu
Set TypingSpeed 100ms

Sleep 500ms
Type "ls | where type == file and size > 10Kb | get name"
Sleep 500ms
Enter
Sleep 5s
' | vhs
```

> **Note**
> this is all written in `nushell` :+1: 

## problem
when i run this, i can see `bash` launching first, then run `nu` from `bash` and finally drop in `nushell`.

i had a look at `shell.go` and couldn't see `nushell` in the list of supported shells, so i thought i could add it to drop directly inside `nushell` :yum: 

## this PR
> **Note**
> i've search for `fish` in the source base and `shell.go` is the only non-test source file i found :yum: 
 
- mirrors the other supported shells
- adds `nushell` which runs `nu --interactive`

## before landing
i'm not familiar with `go` at all, so if i'm missing something, if i should run some tests on my side, ..., please tell me :wink: 

### hope you'll like that :relieved: :tada: 