### PR TITLE
feature/add nushell to the list of shells

### DIFF
--- a/examples/settings/set-shell-nu.gif
+++ b/examples/settings/set-shell-nu.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c780723ac285583a39cc59ab58a5df9d91c44bfd095e3272d450a5378eebe901
+size 25587

--- a/examples/settings/set-shell-nu.tape
+++ b/examples/settings/set-shell-nu.tape
@@ -1,0 +1,10 @@
+Output examples/settings/set-shell-nu.gif
+
+Set FontSize 38
+Set Height 225
+
+Set Shell nu
+
+Sleep 1s
+Type "I am using nu."
+Sleep 2s

--- a/shell.go
+++ b/shell.go
@@ -63,6 +63,6 @@ var Shells = map[string]Shell{
 		Command: []string{"cmd.exe", "/k", "prompt=^> "},
 	},
 	nushell: {
-		Command: []string{"nu", "--interactive"},
+		Command: []string{"nu", "--interactive", "--execute", "let-env PROMPT_COMMAND = { '' }"},
 	},
 }


### PR DESCRIPTION
- add `nushell` to the list of supported shells
- change the name of the shell to the smaller "nu"
- chore(examples): add nushell example
