### PR TITLE
docs: add missing commands in man

### DIFF
--- a/man.go
+++ b/man.go
@@ -41,6 +41,9 @@ The following is a list of all possible commands in VHS:
 * %PageDown% [repeat]
 * %Hide%
 * %Show%
+* %Escape%
+* %Alt%+<key>
+* %Space% [repeat]
 `
 
 	manOutput = `The Output command instructs VHS where to save the output of the recording.


### PR DESCRIPTION
After executing `vhs` I realized some commands were missing.

I've added them to `man.go` file.