### PR TITLE
fix: use os.Environ()

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -12,6 +12,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 )
 
@@ -40,7 +41,7 @@ func buildTtyCmd(port int, shell Shell) *exec.Cmd {
 	//nolint:gosec
 	cmd := exec.Command("ttyd", args...)
 	if shell.Env != nil {
-		cmd.Env = append(shell.Env, cmd.Env...)
+		cmd.Env = append(shell.Env, os.Environ()...)
 	}
 	return cmd
 }


### PR DESCRIPTION
`cmd.Env()`, at that point, is empty, so we're missing all user environment variables...

Since we don't have a way to tell VHS which envs to allow, we should probably keep all of them.

This was working at some point, I think I might have broken it while refactoring the shell init stuff.