### PR TITLE
Feature/source command

### DIFF
--- a/command.go
+++ b/command.go
@@ -3,12 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-rod/rod/lib/input"
+	"github.com/mattn/go-runewidth"
 )
 
 // CommandType is a type that represents a command.
@@ -37,6 +40,7 @@ var CommandTypes = []CommandType{ //nolint: deadcode
 	TAB,
 	TYPE,
 	UP,
+	SOURCE,
 }
 
 // String returns the string representation of the command.
@@ -95,7 +99,12 @@ func (c Command) String() string {
 
 // Execute executes a command on a running instance of vhs.
 func (c Command) Execute(v *VHS) {
-	CommandFuncs[c.Type](c, v)
+	if c.Type == SOURCE {
+		ExecuteSourceTape(c, v)
+	} else {
+		CommandFuncs[c.Type](c, v)
+	}
+
 	if v.recording && v.Options.Test.Output != "" {
 		v.SaveOutput()
 	}
@@ -379,6 +388,52 @@ func ExecuteSetWindowBarSize(c Command, v *VHS) {
 // ExecuteSetWindowBar sets corner radius
 func ExecuteSetBorderRadius(c Command, v *VHS) {
 	v.Options.Video.BorderRadius, _ = strconv.Atoi(c.Args)
+}
+
+const sourceDisplayMaxLength = 10
+
+// ExecuteSourceTape is a CommandFunc that executes all commands of source tape.
+func ExecuteSourceTape(c Command, v *VHS) {
+	tapePath := c.Args
+	var out io.Writer = os.Stdout
+	if quietFlag {
+		out = io.Discard
+	}
+
+	// read tape file
+	tape, err := os.ReadFile(tapePath)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	l := NewLexer(string(tape))
+	p := NewParser(l)
+
+	cmds := p.Parse()
+
+	errs := []error{}
+	for _, parsedErr := range p.Errors() {
+		errs = append(errs, parsedErr)
+	}
+
+	if len(errs) != 0 {
+		fmt.Fprintln(out, ErrorStyle.Render(fmt.Sprintf("tape %s has errors", tapePath)))
+		printErrors(out, tapePath, errs)
+		return
+	}
+
+	displayPath := runewidth.Truncate(strings.TrimSuffix(tapePath, extension), sourceDisplayMaxLength, "…")
+
+	// Run all commands from the sourced tape file.
+	for _, cmd := range cmds {
+		// Output have to be avoid in order to not overwrite output of the original tape.
+		if cmd.Type == SOURCE || cmd.Type == OUTPUT {
+			continue
+		}
+		fmt.Fprintf(out, "%s %s\n", GrayStyle.Render(displayPath+":"), cmd.Highlight(false))
+		CommandFuncs[cmd.Type](cmd, v)
+	}
 }
 
 func getTheme(s string) (Theme, error) {

--- a/command_test.go
+++ b/command_test.go
@@ -6,12 +6,13 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	const numberOfCommands = 21
+	const numberOfCommands = 22
 	if len(CommandTypes) != numberOfCommands {
 		t.Errorf("Expected %d commands, got %d", numberOfCommands, len(CommandTypes))
 	}
 
-	if len(CommandFuncs) != numberOfCommands {
+	const numberOfCommandFuncs = 21
+	if len(CommandFuncs) != numberOfCommandFuncs {
 		t.Errorf("Expected %d commands, got %d", numberOfCommands, len(CommandTypes))
 	}
 }

--- a/man.go
+++ b/man.go
@@ -44,6 +44,7 @@ The following is a list of all possible commands in VHS:
 * %Escape%
 * %Alt%+<key>
 * %Space% [repeat]
+* %Source% <path>.tape
 `
 
 	manOutput = `The Output command instructs VHS where to save the output of the recording.

--- a/parser_source_test.go
+++ b/parser_source_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+type parseSourceTest struct {
+	tape      string
+	srcTape   string
+	errors    []string
+	writeFile bool
+}
+
+func (st *parseSourceTest) run(t *testing.T) {
+	if st.writeFile {
+		err := os.WriteFile("source.tape", []byte(st.srcTape), os.ModePerm)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+
+	l := NewLexer(st.tape)
+	p := NewParser(l)
+
+	_ = p.Parse()
+
+	if len(p.errors) != len(st.errors) {
+		t.Fatalf("Expected errors: %d, errors: %d", len(st.errors), len(p.errors))
+	}
+
+	for i := range st.errors {
+		err := p.errors[i].Msg
+		expected := st.errors[i]
+
+		if err != expected {
+			t.Errorf("Expected error: %s, actual error %s", expected, err)
+		}
+	}
+
+	os.Remove("source.tape")
+}
+
+func TestParseSource(t *testing.T) {
+	t.Run("should not return errors when tape exist and is NOT empty", func(t *testing.T) {
+		test := &parseSourceTest{
+			tape:      "Source source.tape",
+			srcTape:   `Type "echo 'Welcome to VHS!'"`,
+			writeFile: true,
+		}
+
+		test.run(t)
+	})
+
+	t.Run("should return errors when tape NOT found", func(t *testing.T) {
+		test := &parseSourceTest{
+			tape:      "Source source.tape",
+			errors:    []string{"File source.tape not found"},
+			writeFile: false,
+		}
+
+		test.run(t)
+	})
+
+	t.Run("should return error when tape extension is NOT (.tape)", func(t *testing.T) {
+		test := &parseSourceTest{
+			tape:      "Source source.vhs",
+			errors:    []string{"Expected file with .tape extension"},
+			writeFile: true,
+		}
+
+		test.run(t)
+	})
+
+	t.Run("should return error when Source command does NOT have tape path", func(t *testing.T) {
+		test := &parseSourceTest{
+			tape:      "Source",
+			errors:    []string{"Expected path after Source"},
+			writeFile: true,
+		}
+
+		test.run(t)
+	})
+
+	t.Run("should return error when find nested Source commands", func(t *testing.T) {
+		test := &parseSourceTest{
+			tape: "Source source.tape",
+			srcTape: `Type "echo 'Welcome to VHS!'"
+	Source magic.tape
+	Type "goodbye"
+	`,
+			errors:    []string{"Nested Source detected"},
+			writeFile: true,
+		}
+
+		test.run(t)
+	})
+}

--- a/token.go
+++ b/token.go
@@ -15,46 +15,56 @@ type Token struct {
 
 // Tokens for the VHS language
 const (
-	AT              = "@"
-	EQUAL           = "="
-	PLUS            = "+"
-	PERCENT         = "%"
-	SLASH           = "/"
-	DOT             = "."
-	DASH            = "-"
-	PX              = "PX"
-	EM              = "EM"
-	EOF             = "EOF"
-	ILLEGAL         = "ILLEGAL"
-	SPACE           = "SPACE"
-	BACKSPACE       = "BACKSPACE"
-	ALT             = "ALT"
-	CTRL            = "CTRL"
-	ENTER           = "ENTER"
-	NUMBER          = "NUMBER"
-	SET             = "SET"
-	SLEEP           = "SLEEP"
-	STRING          = "STRING"
-	JSON            = "JSON"
-	TYPE            = "TYPE"
-	DOWN            = "DOWN"
-	LEFT            = "LEFT"
-	RIGHT           = "RIGHT"
-	UP              = "UP"
-	TAB             = "TAB"
-	ESCAPE          = "ESCAPE"
-	DELETE          = "DELETE"
-	HOME            = "HOME"
-	INSERT          = "INSERT"
-	END             = "END"
-	HIDE            = "HIDE"
-	REQUIRE         = "REQUIRE"
-	SHOW            = "SHOW"
-	OUTPUT          = "OUTPUT"
-	MILLISECONDS    = "MILLISECONDS"
-	SECONDS         = "SECONDS"
-	MINUTES         = "MINUTES"
-	COMMENT         = "COMMENT"
+	AT      = "@"
+	EQUAL   = "="
+	PLUS    = "+"
+	PERCENT = "%"
+	SLASH   = "/"
+	DOT     = "."
+	DASH    = "-"
+
+	EM           = "EM"
+	MILLISECONDS = "MILLISECONDS"
+	MINUTES      = "MINUTES"
+	PX           = "PX"
+	SECONDS      = "SECONDS"
+
+	EOF     = "EOF"
+	ILLEGAL = "ILLEGAL"
+
+	ALT       = "ALT"
+	BACKSPACE = "BACKSPACE"
+	CTRL      = "CTRL"
+	DELETE    = "DELETE"
+	END       = "END"
+	ENTER     = "ENTER"
+	ESCAPE    = "ESCAPE"
+	HOME      = "HOME"
+	INSERT    = "INSERT"
+	PAGEDOWN  = "PAGEDOWN"
+	PAGEUP    = "PAGEUP"
+	SLEEP     = "SLEEP"
+	SPACE     = "SPACE"
+	TAB       = "TAB"
+
+	COMMENT = "COMMENT"
+	NUMBER  = "NUMBER"
+	STRING  = "STRING"
+	JSON    = "JSON"
+
+	DOWN  = "DOWN"
+	LEFT  = "LEFT"
+	RIGHT = "RIGHT"
+	UP    = "UP"
+
+	HIDE    = "HIDE"
+	OUTPUT  = "OUTPUT"
+	REQUIRE = "REQUIRE"
+	SET     = "SET"
+	SHOW    = "SHOW"
+	SOURCE  = "SOURCE"
+	TYPE    = "TYPE"
+
 	SHELL           = "SHELL"
 	FONT_FAMILY     = "FONT_FAMILY" //nolint:revive
 	FONT_SIZE       = "FONT_SIZE"   //nolint:revive
@@ -67,8 +77,6 @@ const (
 	TYPING_SPEED    = "TYPING_SPEED"   //nolint:revive
 	PADDING         = "PADDING"
 	THEME           = "THEME"
-	PAGEUP          = "PAGEUP"
-	PAGEDOWN        = "PAGEDOWN"
 	LOOP_OFFSET     = "LOOP_OFFSET"     //nolint:revive
 	MARGIN_FILL     = "MARGIN_FILL"     //nolint:revive
 	MARGIN          = "MARGIN"          //nolint:revive
@@ -122,6 +130,7 @@ var keywords = map[string]TokenType{
 	"Theme":         THEME,
 	"Width":         WIDTH,
 	"LoopOffset":    LOOP_OFFSET,
+	"Source":        SOURCE,
 }
 
 // IsSetting returns whether a token is a setting.
@@ -143,7 +152,7 @@ func IsCommand(t TokenType) bool {
 	case TYPE, SLEEP,
 		UP, DOWN, RIGHT, LEFT, PAGEUP, PAGEDOWN,
 		ENTER, BACKSPACE, DELETE, TAB,
-		ESCAPE, HOME, INSERT, END, CTRL:
+		ESCAPE, HOME, INSERT, END, CTRL, SOURCE:
 		return true
 	default:
 		return false


### PR DESCRIPTION
This pull request adds new `source` command for include tape commands into other tape.
It's based on #133 and #220 

### Example

demo.tape 
```
Output ./tapes/demo.gif

Set FontSize 32
Set Width 1200
Set Height 600
Set LoopOffset 50%

Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter

Sleep 1s

Source ./tapes/external.tape

Type "Thanks for the help external tape :)"
```

external.tape
```
Type "echo 'I'm an external tape'" Enter
Enter
Sleep 1s

Type "Goodbye friend"
Enter
Sleep 1s
```

![Screenshot from 2023-04-01 16-56-47](https://user-images.githubusercontent.com/43180519/229296880-32d4873f-7670-4e04-9e36-d7ea4c81e19c.png)

### Wrong example

![Screenshot from 2023-04-01 17-00-22](https://user-images.githubusercontent.com/43180519/229296934-768e8391-a591-4757-91bf-8c80a3b17221.png)
