### PR TITLE
docs: Added ColorfulRight and RingsRight

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Set MarginFill "#6B50FF"
 
 #### Set Window Bar
 
-Set the type of window bar (Colorful, Rings) of the terminal window with the `Set WindowBar` command.
+Set the type of window bar (Colorful, ColorfulRight, Rings, RingsRight) on the terminal window with the `Set WindowBar` command.
 
 ```elixir
 Set WindowBar Colorful

--- a/examples/demo.tape
+++ b/examples/demo.tape
@@ -23,7 +23,7 @@
 #   Set MarginFill <file|#000000>   Set the file or color the margin will be filled with.
 #   Set Margin <number>             Set the size of the margin. Has no effect if MarginFill isn't set.
 #   Set BorderRadius <number>       Set terminal border radius, in pixels.
-#   Set WindowBar <string>          Set window bar type. (one of: Rings, Colorful)
+#   Set WindowBar <string>          Set window bar type. (one of: Rings, RingsRight, Colorful, ColorfulRight)
 #   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 40.
 #
 # Sleep:

--- a/parser.go
+++ b/parser.go
@@ -242,7 +242,7 @@ func (p *Parser) parseSet() Command {
 		if !isValidWindowBar(windowBar) {
 			p.errors = append(
 				p.errors,
-				NewError(p.cur, windowBar+" is not valid. Must be one of Colorful or Rings."),
+				NewError(p.cur, windowBar+" is not a valid bar style."),
 			)
 		}
 	case MARGIN_FILL:


### PR DESCRIPTION
Currently, the documentation only mentions two of the four possible `WindowBar` styles. This PR fixes that.

It is true that the `*Right` styles will be used less than the default styles, but we probably still want to mention them in the docs.
