### PR TITLE
fix: powershell run command

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -40,12 +40,11 @@ var Shells = map[string]Shell{
 	powershell: {
 		Command: []string{
 			"powershell",
-			"-Login",
 			"-NoLogo",
 			"-NoExit",
 			"-NoProfile",
 			"-Command",
-			`Set-PSReadLineOption -HistorySaveStyle SaveNothing; Function prompt { Write-Host -ForegroundColor Blue -NoNewLine '>'; return ' ' }`,
+			`Set-PSReadLineOption -HistorySaveStyle SaveNothing; function prompt { Write-Host '>' -NoNewLine -ForegroundColor Blue; return ' ' }`,
 		},
 	},
 	pwsh: {


### PR DESCRIPTION
Fix #289 in [`shell.go` file](https://github.com/charmbracelet/vhs/blob/main/shell.go).

Remove `-Login` parameter because [official documentation hasn't it](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#syntax).

After removing `-Login` command `vhs` stacks on `Set Shell powershell` instruction. Fix this by changing `-Command` parameter.

**Example `.tape` file:** 
```
Output "demo.gif"

Set Shell powershell

Type "echo 'test'"
Sleep 500ms
Enter

Sleep 2s
```

**Fixed output:**

![Made with VHS](https://vhs.charm.sh/vhs-4h0CfnmdwRXwW52a3TGxnA.gif) 
