### PR TITLE
fix: record sleep only in supported time units

### DIFF
--- a/record.go
+++ b/record.go
@@ -158,7 +158,7 @@ func inputToTape(input string) string {
 		// characters.
 		if TokenType(lines[i]) == SLEEP {
 			sleep := sleepThreshold * time.Duration(repeat)
-			if sleep >= 60*time.Second {
+			if sleep >= time.Minute {
 				sanitized.WriteString(fmt.Sprintf("%s %gs", TokenType(SLEEP), sleep.Seconds()))
 			} else {
 				sanitized.WriteString(fmt.Sprintf("%s %s", TokenType(SLEEP), sleep))

--- a/record.go
+++ b/record.go
@@ -158,7 +158,11 @@ func inputToTape(input string) string {
 		// characters.
 		if TokenType(lines[i]) == SLEEP {
 			sleep := sleepThreshold * time.Duration(repeat)
-			sanitized.WriteString(fmt.Sprintf("%s %s", TokenType(SLEEP), sleep))
+			if sleep >= 60*time.Second {
+				sanitized.WriteString(fmt.Sprintf("%s %gs", TokenType(SLEEP), sleep.Seconds()))
+			} else {
+				sanitized.WriteString(fmt.Sprintf("%s %s", TokenType(SLEEP), sleep))
+			}
 		} else if strings.HasPrefix(lines[i], CTRL) {
 			for j := 0; j < repeat; j++ {
 				sanitized.WriteString("Ctrl" + strings.TrimPrefix(lines[i], CTRL) + "\n")

--- a/record_test.go
+++ b/record_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -25,7 +26,10 @@ CTRL+C
 CTRL+W
 CTRL+A
 CTRL+E
+SLEEP
+SLEEP
 ALT+.
+SLEEP
 exit
 `
 
@@ -44,9 +48,19 @@ Ctrl+C
 Ctrl+W
 Ctrl+A
 Ctrl+E
+Sleep 1s
 Alt+.
+Sleep 500ms
 `
+	got := inputToTape(input)
+	if want != got {
+		t.Fatalf("want:\n%s\ngot:\n%s\n", want, got)
+	}
+}
 
+func TestInputToTapeLongSleep(t *testing.T) {
+	input := strings.Repeat("SLEEP\n", 121) + "exit"
+	want := "Sleep 60.5s\n"
 	got := inputToTape(input)
 	if want != got {
 		t.Fatalf("want:\n%s\ngot:\n%s\n", want, got)


### PR DESCRIPTION
Fix the issue described in #287 when record writes duration in unsupported units by keeping it in seconds if sleep was more than 1min