### PR TITLE
fix: set color in fish shell using correct syntax

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -34,7 +34,7 @@ var Shells = map[string]Shell{
 			"--no-config",
 			"--private",
 			"-C", "function fish_greeting; end",
-			"-C", `function fish_prompt; echo -e "$(set_color 5B56E0)> $(set_color normal)"; end`,
+			"-C", `function fish_prompt; set_color 5B56E0; echo -n "> "; set_color normal; end`,
 		},
 	},
 	powershell: {


### PR DESCRIPTION
When setting colour in the fish shell using `$(set_color ...)` design, we get an error `fish: $(...) is not supported` in the output gif file.

This PR fixes this error. The colours are now set according to the fish shell documentation:
https://fishshell.com/docs/current/cmds/set_color.html#examples

The `demo.tape` was used for testing:
```elixir
Output demo.gif

Set FontSize 24
Set Width 1200
Set Height 600
Set Shell fish

Type "flutter create --platforms=linux example"
Sleep 500ms

Enter
Sleep 5s
```

Bug example:
![bug example](https://github.com/charmbracelet/vhs/assets/32034707/bf3b459d-8ed7-4e29-88f6-b8a80146983a)

Example after fixing the bug:
![bug fix example](https://github.com/charmbracelet/vhs/assets/32034707/25782d4a-3098-406b-b4a6-506d46fb08ca)

Environment:
```sh
~ $ fish --version
fish, version 3.3.1

~ $ cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.2 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```