### PR TITLE
fix: hint linguist to highlight tape files as elixir

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,6 @@
 **/*.mp4 filter=lfs diff=lfs merge=lfs -text
 **/*.webm filter=lfs diff=lfs merge=lfs -text
 **/*.png filter=lfs diff=lfs merge=lfs -text
+*.tape linguist-language=elixir
 themes*.json linguist-generated
 THEMES.md linguist-generated


### PR DESCRIPTION
this will hint linguist to properly highlight tape files as elixir (like we do in the readme).

Once linguist supports tape files natively, we can remove this :) 