### PR TITLE
add note on TypingSpeed for new users in `demo.tape`

### DIFF
--- a/examples/demo.tape
+++ b/examples/demo.tape
@@ -25,6 +25,7 @@
 #   Set BorderRadius <number>       Set terminal border radius, in pixels.
 #   Set WindowBar <string>          Set window bar type. (one of: Rings, RingsRight, Colorful, ColorfulRight)
 #   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 40.
+#   Set TypingSpeed <time>          Set the typing speed of the terminal. Default is 50ms
 #
 # Sleep:
 #   Sleep <time>                    Sleep for a set amount of <time> in seconds


### PR DESCRIPTION
Added note to the comment that is generated when a user calls `vhs new` to call out that `TypingSpeed` can be customized globally, and defaults to 50ms