### PR TITLE
feat: add Apple Symbols font fallback for braille characters

### DIFF
--- a/command.go
+++ b/command.go
@@ -302,7 +302,7 @@ func ExecuteSetFontSize(c Command, v *VHS) {
 // ExecuteSetFontFamily applies the font family on the vhs.
 func ExecuteSetFontFamily(c Command, v *VHS) {
 	v.Options.FontFamily = c.Args
-	_, _ = v.Page.Eval(fmt.Sprintf("() => term.options.fontFamily = '%s'", c.Args))
+	_, _ = v.Page.Eval(fmt.Sprintf("() => term.options.fontFamily = '%s'", withSymbolsFallback(c.Args)))
 }
 
 // ExecuteSetHeight applies the height on the vhs.

--- a/vhs.go
+++ b/vhs.go
@@ -58,7 +58,7 @@ const (
 	defaultCursorBlink   = true
 )
 
-var defaultFontFamily = strings.Join([]string{
+var defaultFontFamily = withSymbolsFallback(strings.Join([]string{
 	"JetBrains Mono",
 	"DejaVu Sans Mono",
 	"Menlo",
@@ -69,7 +69,15 @@ var defaultFontFamily = strings.Join([]string{
 	"Consolas",
 	"ui-monospace",
 	"monospace",
-}, fontsSeparator)
+}, fontsSeparator))
+
+var symbolsFallback = []string{
+	"Apple Symbols",
+}
+
+func withSymbolsFallback(font string) string {
+	return font + fontsSeparator + strings.Join(symbolsFallback, fontsSeparator)
+}
 
 // DefaultVHSOptions returns the default set of options to use for the setup function.
 func DefaultVHSOptions() Options {


### PR DESCRIPTION
This PR adds font fallback to Apple Symbols which allows braille characters to
be rendered without empty circles.
