### PR TITLE
Correction of condition logic for env variable "VHS_NO_SANDBOX"

### DIFF
--- a/vhs.go
+++ b/vhs.go
@@ -121,7 +121,7 @@ func (vhs *VHS) Start() error {
 	}
 
 	path, _ := launcher.LookPath()
-	enableNoSandbox := os.Getenv("VHS_NO_SANDBOX") != ""
+	enableNoSandbox := os.Getenv("VHS_NO_SANDBOX") != "true"
 	u, err := launcher.New().Leakless(false).Bin(path).NoSandbox(enableNoSandbox).Launch()
 	if err != nil {
 		return fmt.Errorf("could not launch browser: %w", err)


### PR DESCRIPTION
The condition _enableNoSandbox := os.Getenv("VHS_NO_SANDBOX") != ""_  at any value of VHS_NO_SANDBOX will be true.