### PR TITLE
feat: improve vhs new

### DIFF
--- a/examples/demo.tape
+++ b/examples/demo.tape
@@ -35,6 +35,7 @@
 #                                   <time> delay between each character
 #
 # Keys:
+#   Escape[@<time>] [number]        Press the Escape key
 #   Backspace[@<time>] [number]     Press the Backspace key
 #   Down[@<time>] [number]          Press the Down key
 #   Enter[@<time>] [number]         Press the Enter key

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -180,14 +181,15 @@ var (
 		Short: "Create a new tape file with example tape file contents and documentation",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			fileName := strings.TrimSuffix(args[0], extension) + extension
+			name := strings.TrimSuffix(args[0], extension)
+			fileName := name + extension
 
 			f, err := os.Create(fileName)
 			if err != nil {
 				return err
 			}
 
-			_, err = f.Write(DemoTape)
+			_, err = f.Write(bytes.Replace(DemoTape, []byte("examples/demo.gif"), []byte(name+".gif"), 1))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- added missing `Escape` to embedded tape
- replace the default `examples/demo.gif` to the given name plus `.gif` ext