### PR TITLE
Fix VHS for Nushell version ^0.83

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -62,6 +62,6 @@ var Shells = map[string]Shell{
 		Command: []string{"cmd.exe", "/k", "prompt=^> "},
 	},
 	nushell: {
-		Command: []string{"nu", "--interactive", "--execute", "$env.PROMPT_COMMAND = { '' }"},
+		Command: []string{"nu", "--execute", "$env.PROMPT_COMMAND = {''}"},
 	},
 }

--- a/shell.go
+++ b/shell.go
@@ -62,6 +62,6 @@ var Shells = map[string]Shell{
 		Command: []string{"cmd.exe", "/k", "prompt=^> "},
 	},
 	nushell: {
-		Command: []string{"nu", "--interactive", "--execute", "let-env PROMPT_COMMAND = { '' }"},
+		Command: []string{"nu", "--interactive", "--execute", "$env.PROMPT_COMMAND = { '' }"},
 	},
 }


### PR DESCRIPTION
## Issue
Since Nushell version 0.83, the `let-env` command has been [removed](https://www.nushell.sh/blog/2023-07-25-nushell_0_83.html#breaking-changes).

This breaks VHS when recording `nu` tapes.

## Fix
Replace `let-env VAR` with `$env.VAR`

Also the --interactive command is redundant, since the --execute flag also starts the interactive mode
