### PR TITLE
chore: go mod tidy, and keep it tidy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,21 @@ jobs:
         with:
           only-new-issues: true
 
+  tidy:
+    name: Remain 'go mod tidy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+      - name: Verify tidyness
+        run: |
+          go mod tidy
+          if ! git diff --quiet go.mod go.sum; then
+            echo "'go mod tidy' resulted in changes:"
+            git diff go.mod go.sum
+            echo "Please commit these changes."
+          fi

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/agnivade/levenshtein v1.1.1
+	github.com/atotto/clipboard v0.1.4
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/keygen v0.4.3
@@ -27,7 +28,6 @@ require (
 require (
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/caarlos0/sshmarshal v0.1.0 // indirect


### PR DESCRIPTION
Runs 'go mod tidy' and checks in the result.

To ensure that the go.mod and go.sum remain tidy,
adds a new lint job that will fail if the files change
after running 'go mod tidy'.
