### PR TITLE
chore: Fix lint on main

### DIFF
--- a/command.go
+++ b/command.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/atotto/clipboard"
 	"io"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/atotto/clipboard"
 	"github.com/go-rod/rod/lib/input"
 	"github.com/mattn/go-runewidth"
 )
@@ -264,10 +264,12 @@ func ExecuteOutput(c Command, v *VHS) {
 	}
 }
 
+// ExecuteCopy copies text to the clipboard.
 func ExecuteCopy(c Command, _ *VHS) {
 	_ = clipboard.WriteAll(c.Args)
 }
 
+// ExecutePaste pastes text from the clipboard.
 func ExecutePaste(_ Command, v *VHS) {
 	clip, err := clipboard.ReadAll()
 	if err != nil {


### PR DESCRIPTION
golangci-lint currently fails on main with:

```
command.go:6: File is not `goimports`-ed (goimports)
        "github.com/atotto/clipboard"
command.go:267:1: exported: exported function ExecuteCopy should have comment or be unexported (revive)
func ExecuteCopy(c Command, _ *VHS) {
^
command.go:271:1: exported: exported function ExecutePaste should have comment or be unexported (revive)
func ExecutePaste(_ Command, v *VHS) {
^
```

This fixes all three issues.
