### PR TITLE
Allow Ctrl+Space

### DIFF
--- a/command.go
+++ b/command.go
@@ -167,6 +167,8 @@ func ExecuteCtrl(c Command, v *VHS) {
 			inputKey = &input.AltLeft
 		case "Enter":
 			inputKey = &input.Enter
+		case "Space":
+			inputKey = &input.Space
 		default:
 			r := rune(key[0])
 			if k, ok := keymap[r]; ok {

--- a/command.go
+++ b/command.go
@@ -169,6 +169,8 @@ func ExecuteCtrl(c Command, v *VHS) {
 			inputKey = &input.Enter
 		case "Space":
 			inputKey = &input.Space
+		case "Backspace":
+			inputKey = &input.Backspace
 		default:
 			r := rune(key[0])
 			if k, ok := keymap[r]; ok {

--- a/parser.go
+++ b/parser.go
@@ -172,6 +172,7 @@ func (p *Parser) parseCtrl() Command {
 		switch {
 		case peek.Type == ENTER,
 			peek.Type == SPACE,
+			peek.Type == BACKSPACE,
 			peek.Type == STRING && len(peek.Literal) == 1:
 			args = append(args, peek.Literal)
 		default:

--- a/parser.go
+++ b/parser.go
@@ -147,16 +147,26 @@ func (p *Parser) parseTime() string {
 func (p *Parser) parseCtrl() Command {
 	var args []string
 
+	inModifierChain := true
 	for p.peek.Type == PLUS {
 		p.nextToken()
 		peek := p.peek
 
 		// Get key from keywords and check if it's a valid modifier
 		if k := keywords[peek.Literal]; IsModifier(k) {
+			if !inModifierChain {
+				p.errors = append(p.errors, NewError(p.cur, "Modifiers must come before other characters"))
+				// Clear args so the error is returned
+				args = nil
+				continue
+			}
+
 			args = append(args, peek.Literal)
 			p.nextToken()
 			continue
 		}
+
+		inModifierChain = false
 
 		// Add key argument.
 		switch {

--- a/parser.go
+++ b/parser.go
@@ -161,6 +161,7 @@ func (p *Parser) parseCtrl() Command {
 		// Add key argument.
 		switch {
 		case peek.Type == ENTER,
+			peek.Type == SPACE,
 			peek.Type == STRING && len(peek.Literal) == 1:
 			args = append(args, peek.Literal)
 		default:

--- a/parser.go
+++ b/parser.go
@@ -152,26 +152,25 @@ func (p *Parser) parseCtrl() Command {
 		peek := p.peek
 
 		// Get key from keywords and check if it's a valid modifier
-		if k, ok := keywords[peek.Literal]; ok && peek.Type != ENTER {
-			p.nextToken()
-			if IsModifier(k) {
-				args = append(args, peek.Literal)
-			} else {
-				p.errors = append(p.errors, NewError(p.cur, "not a valid modifier"))
-			}
-		}
-
-		// Add key argument
-		if peek.Type == ENTER || peek.Type == STRING && len(peek.Literal) == 1 {
-			p.nextToken()
+		if k := keywords[peek.Literal]; IsModifier(k) {
 			args = append(args, peek.Literal)
+			p.nextToken()
+			continue
 		}
 
-		// Key arguments with len > 1 are not valid
-		if peek.Type == STRING && len(peek.Literal) > 1 {
-			p.nextToken()
-			p.errors = append(p.errors, NewError(p.cur, "Invalid control argument: "+p.cur.Literal))
+		// Add key argument.
+		switch {
+		case peek.Type == ENTER,
+			peek.Type == STRING && len(peek.Literal) == 1:
+			args = append(args, peek.Literal)
+		default:
+			// Key arguments with len > 1 are not valid
+			p.errors = append(p.errors,
+				NewError(p.cur, "Not a valid modifier"),
+				NewError(p.cur, "Invalid control argument: "+p.cur.Literal))
 		}
+
+		p.nextToken()
 	}
 
 	if len(args) == 0 {

--- a/parser_test.go
+++ b/parser_test.go
@@ -220,10 +220,14 @@ func TestParseCtrl(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "should parse with out of order modifiers",
-			tape:     "Ctrl+Shift+C+Alt",
-			wantArgs: []string{"Shift", "C", "Alt"},
-			wantErr:  false,
+			name:    "should not parse with out of order modifiers",
+			tape:    "Ctrl+Shift+C+Alt",
+			wantErr: true,
+		},
+		{
+			name:    "should not parse with out of order modifiers",
+			tape:    "Ctrl+Shift+C+Alt+C",
+			wantErr: true,
 		},
 		{
 			tape:    "Ctrl+Alt+Right",

--- a/parser_test.go
+++ b/parser_test.go
@@ -234,9 +234,10 @@ func TestParseCtrl(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "Ctrl+Backspace",
-			tape:    "Ctrl+Backspace",
-			wantErr: true,
+			name:     "Ctrl+Backspace",
+			tape:     "Ctrl+Backspace",
+			wantArgs: []string{"Backspace"},
+			wantErr:  false,
 		},
 		{
 			name:     "Ctrl+Space",

--- a/parser_test.go
+++ b/parser_test.go
@@ -226,7 +226,6 @@ func TestParseCtrl(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:    "Ctrl+Alt+Right",
 			tape:    "Ctrl+Alt+Right",
 			wantErr: true,
 		},
@@ -234,6 +233,12 @@ func TestParseCtrl(t *testing.T) {
 			name:    "Ctrl+Backspace",
 			tape:    "Ctrl+Backspace",
 			wantErr: true,
+		},
+		{
+			name:     "Ctrl+Space",
+			tape:     "Ctrl+Space",
+			wantArgs: []string{"Space"},
+			wantErr:  false,
 		},
 	}
 


### PR DESCRIPTION
I'd like to record tapes that can type Ctrl+Space to trigger a keybinding I have in tmux. I could achieve this by remapping the keybinding temporarily for VHS, but it was nearly as easy to just make this PR instead.

A similar change was made recently in https://github.com/charmbracelet/vhs/commit/b5f8be82aec8d538bd00149985fdb9dfa50e5d4f to allow Ctrl+Shift+Alt+Enter, so I figured this might also be acceptable.