### PR TITLE
feat: Set the shells starting directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ Set the shell with the `Set Shell <shell>` command
 Set Shell fish
 ```
 
+#### Set CWD
+
+Sets the directory the terminal will start in. Must be quoted.
+
+```elixir
+Set CWD "/tmp"
+```
+
 #### Set Font Size
 
 Set the font size with the `Set FontSize <number>` command.

--- a/command.go
+++ b/command.go
@@ -11,12 +11,11 @@ import (
 	"time"
 
 	"github.com/atotto/clipboard"
-	"github.com/go-rod/rod/lib/input"
-	"github.com/mattn/go-runewidth"
-
 	"github.com/charmbracelet/vhs/lexer"
 	"github.com/charmbracelet/vhs/parser"
 	"github.com/charmbracelet/vhs/token"
+	"github.com/go-rod/rod/lib/input"
+	"github.com/mattn/go-runewidth"
 )
 
 // Execute executes a command on a running instance of vhs.
@@ -312,9 +311,7 @@ func ExecuteSetFontSize(c parser.Command, v *VHS) {
 // ExecuteSetFontFamily applies the font family on the vhs.
 func ExecuteSetFontFamily(c parser.Command, v *VHS) {
 	v.Options.FontFamily = c.Args
-	_, _ = v.Page.Eval(
-		fmt.Sprintf("() => term.options.fontFamily = '%s'", withSymbolsFallback(c.Args)),
-	)
+	_, _ = v.Page.Eval(fmt.Sprintf("() => term.options.fontFamily = '%s'", withSymbolsFallback(c.Args)))
 }
 
 // ExecuteSetHeight applies the height on the vhs.
@@ -482,11 +479,7 @@ func ExecuteSourceTape(c parser.Command, v *VHS) {
 		return
 	}
 
-	displayPath := runewidth.Truncate(
-		strings.TrimSuffix(tapePath, extension),
-		sourceDisplayMaxLength,
-		"…",
-	)
+	displayPath := runewidth.Truncate(strings.TrimSuffix(tapePath, extension), sourceDisplayMaxLength, "…")
 
 	// Run all commands from the sourced tape file.
 	for _, cmd := range cmds {

--- a/command.go
+++ b/command.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/atotto/clipboard"
+	"github.com/go-rod/rod/lib/input"
+	"github.com/mattn/go-runewidth"
+
 	"github.com/charmbracelet/vhs/lexer"
 	"github.com/charmbracelet/vhs/parser"
 	"github.com/charmbracelet/vhs/token"
-	"github.com/go-rod/rod/lib/input"
-	"github.com/mattn/go-runewidth"
 )
 
 // Execute executes a command on a running instance of vhs.
@@ -279,6 +280,7 @@ var Settings = map[string]CommandFunc{
 	"TypingSpeed":   ExecuteSetTypingSpeed,
 	"Width":         ExecuteSetWidth,
 	"Shell":         ExecuteSetShell,
+	"CWD":           ExecuteSetCWD,
 	"LoopOffset":    ExecuteLoopOffset,
 	"MarginFill":    ExecuteSetMarginFill,
 	"Margin":        ExecuteSetMargin,
@@ -310,7 +312,9 @@ func ExecuteSetFontSize(c parser.Command, v *VHS) {
 // ExecuteSetFontFamily applies the font family on the vhs.
 func ExecuteSetFontFamily(c parser.Command, v *VHS) {
 	v.Options.FontFamily = c.Args
-	_, _ = v.Page.Eval(fmt.Sprintf("() => term.options.fontFamily = '%s'", withSymbolsFallback(c.Args)))
+	_, _ = v.Page.Eval(
+		fmt.Sprintf("() => term.options.fontFamily = '%s'", withSymbolsFallback(c.Args)),
+	)
 }
 
 // ExecuteSetHeight applies the height on the vhs.
@@ -328,6 +332,11 @@ func ExecuteSetShell(c parser.Command, v *VHS) {
 	if s, ok := Shells[c.Args]; ok {
 		v.Options.Shell = s
 	}
+}
+
+// ExecuteSetCWD applies the current working directory on the vhs.
+func ExecuteSetCWD(c parser.Command, v *VHS) {
+	v.Options.CWD = c.Args
 }
 
 const (
@@ -473,7 +482,11 @@ func ExecuteSourceTape(c parser.Command, v *VHS) {
 		return
 	}
 
-	displayPath := runewidth.Truncate(strings.TrimSuffix(tapePath, extension), sourceDisplayMaxLength, "…")
+	displayPath := runewidth.Truncate(
+		strings.TrimSuffix(tapePath, extension),
+		sourceDisplayMaxLength,
+		"…",
+	)
 
 	// Run all commands from the sourced tape file.
 	for _, cmd := range cmds {

--- a/evaluator.go
+++ b/evaluator.go
@@ -139,13 +139,7 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 			fmt.Fprintln(out, Highlight(cmd, true))
 			continue
 		}
-		fmt.Fprintln(
-			out,
-			Highlight(
-				cmd,
-				!v.recording || cmd.Type == token.SHOW || cmd.Type == token.HIDE || isSetting,
-			),
-		)
+		fmt.Fprintln(out, Highlight(cmd, !v.recording || cmd.Type == token.SHOW || cmd.Type == token.HIDE || isSetting))
 		Execute(cmd, &v)
 	}
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -29,7 +29,7 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 
 	v := New()
 	for _, cmd := range cmds {
-		if cmd.Type == token.SET && cmd.Options == "Shell" {
+		if cmd.Type == token.SET && (cmd.Options == "Shell" || cmd.Options == "CWD") {
 			Execute(cmd, &v)
 		}
 	}
@@ -139,7 +139,13 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 			fmt.Fprintln(out, Highlight(cmd, true))
 			continue
 		}
-		fmt.Fprintln(out, Highlight(cmd, !v.recording || cmd.Type == token.SHOW || cmd.Type == token.HIDE || isSetting))
+		fmt.Fprintln(
+			out,
+			Highlight(
+				cmd,
+				!v.recording || cmd.Type == token.SHOW || cmd.Type == token.HIDE || isSetting,
+			),
+		)
 		Execute(cmd, &v)
 	}
 

--- a/examples/fixtures/all.tape
+++ b/examples/fixtures/all.tape
@@ -7,6 +7,7 @@ Output examples/fixtures/all.webm
 
 # Settings:
 Set Shell "fish"
+Set CWD ".."
 Set FontSize 22
 Set FontFamily "DejaVu Sans Mono"
 Set Height 600

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -255,10 +255,7 @@ func (p *Parser) parseCtrl() Command {
 		// Get key from keywords and check if it's a valid modifier
 		if k := token.Keywords[peek.Literal]; token.IsModifier(k) {
 			if !inModifierChain {
-				p.errors = append(
-					p.errors,
-					NewError(p.cur, "Modifiers must come before other characters"),
-				)
+				p.errors = append(p.errors, NewError(p.cur, "Modifiers must come before other characters"))
 				// Clear args so the error is returned
 				args = nil
 				continue
@@ -289,10 +286,7 @@ func (p *Parser) parseCtrl() Command {
 	}
 
 	if len(args) == 0 {
-		p.errors = append(
-			p.errors,
-			NewError(p.cur, "Expected control character with args, got "+p.cur.Literal),
-		)
+		p.errors = append(p.errors, NewError(p.cur, "Expected control character with args, got "+p.cur.Literal))
 	}
 
 	ctrlArgs := strings.Join(args, " ")
@@ -653,10 +647,7 @@ func (p *Parser) parseSource() Command {
 	// Check src errors
 	srcErrors := srcParser.Errors()
 	if len(srcErrors) > 0 {
-		p.errors = append(
-			p.errors,
-			NewError(p.peek, fmt.Sprintf("%s has %d errors", srcPath, len(srcErrors))),
-		)
+		p.errors = append(p.errors, NewError(p.peek, fmt.Sprintf("%s has %d errors", srcPath, len(srcErrors))))
 		p.nextToken()
 		return cmd
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -456,14 +456,32 @@ func (p *Parser) parseSet() Command {
 	case token.CWD:
 		cmd.Args = p.peek.Literal
 		p.nextToken()
-		//TODO validate the CWD is a valid path
 
+    cwd := p.cur.Literal
+
+    if !isDirectory(cwd) {
+      p.errors = append(
+        p.errors,
+        NewError(p.cur, cwd+" is not a valid directory."),
+      )
+    }
 	default:
 		cmd.Args = p.peek.Literal
 		p.nextToken()
 	}
 
 	return cmd
+}
+
+func isDirectory(path string) bool {
+  fileInfo, err := os.Stat(path)
+  if os.IsNotExist(err){
+    return false
+  }else if fileInfo.IsDir() {
+    return true
+  } else {
+    return false
+  }
 }
 
 // parseSleep parses a sleep command.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -255,7 +255,10 @@ func (p *Parser) parseCtrl() Command {
 		// Get key from keywords and check if it's a valid modifier
 		if k := token.Keywords[peek.Literal]; token.IsModifier(k) {
 			if !inModifierChain {
-				p.errors = append(p.errors, NewError(p.cur, "Modifiers must come before other characters"))
+				p.errors = append(
+					p.errors,
+					NewError(p.cur, "Modifiers must come before other characters"),
+				)
 				// Clear args so the error is returned
 				args = nil
 				continue
@@ -286,7 +289,10 @@ func (p *Parser) parseCtrl() Command {
 	}
 
 	if len(args) == 0 {
-		p.errors = append(p.errors, NewError(p.cur, "Expected control character with args, got "+p.cur.Literal))
+		p.errors = append(
+			p.errors,
+			NewError(p.cur, "Expected control character with args, got "+p.cur.Literal),
+		)
 	}
 
 	ctrlArgs := strings.Join(args, " ")
@@ -452,6 +458,11 @@ func (p *Parser) parseSet() Command {
 				NewError(p.cur, "expected boolean value."),
 			)
 		}
+
+	case token.CWD:
+		cmd.Args = p.peek.Literal
+		p.nextToken()
+		//TODO validate the CWD is a valid path
 
 	default:
 		cmd.Args = p.peek.Literal
@@ -642,7 +653,10 @@ func (p *Parser) parseSource() Command {
 	// Check src errors
 	srcErrors := srcParser.Errors()
 	if len(srcErrors) > 0 {
-		p.errors = append(p.errors, NewError(p.peek, fmt.Sprintf("%s has %d errors", srcPath, len(srcErrors))))
+		p.errors = append(
+			p.errors,
+			NewError(p.peek, fmt.Sprintf("%s has %d errors", srcPath, len(srcErrors))),
+		)
 		p.nextToken()
 		return cmd
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -114,6 +114,7 @@ func TestParseTapeFile(t *testing.T) {
 		{Type: token.OUTPUT, Options: ".mp4", Args: "examples/fixtures/all.mp4"},
 		{Type: token.OUTPUT, Options: ".webm", Args: "examples/fixtures/all.webm"},
 		{Type: token.SET, Options: "Shell", Args: "fish"},
+		{Type: token.SET, Options: "CWD", Args: ".."},
 		{Type: token.SET, Options: "FontSize", Args: "22"},
 		{Type: token.SET, Options: "FontFamily", Args: "DejaVu Sans Mono"},
 		{Type: token.SET, Options: "Height", Args: "600"},

--- a/token/token.go
+++ b/token/token.go
@@ -72,6 +72,7 @@ const (
 	COPY            = "COPY"
 	PASTE           = "PASTE"
 	SHELL           = "SHELL"
+	CWD             = "CWD"
 	FONT_FAMILY     = "FONT_FAMILY" //nolint:revive
 	FONT_SIZE       = "FONT_SIZE"   //nolint:revive
 	FRAMERATE       = "FRAMERATE"
@@ -124,6 +125,7 @@ var Keywords = map[string]Type{
 	"Show":          SHOW,
 	"Output":        OUTPUT,
 	"Shell":         SHELL,
+	"CWD":           CWD,
 	"FontFamily":    FONT_FAMILY,
 	"MarginFill":    MARGIN_FILL,
 	"Margin":        MARGIN,
@@ -153,7 +155,7 @@ var Keywords = map[string]Type{
 // IsSetting returns whether a token is a setting.
 func IsSetting(t Type) bool {
 	switch t {
-	case SHELL, FONT_FAMILY, FONT_SIZE, LETTER_SPACING, LINE_HEIGHT,
+	case SHELL, CWD, FONT_FAMILY, FONT_SIZE, LETTER_SPACING, LINE_HEIGHT,
 		FRAMERATE, TYPING_SPEED, THEME, PLAYBACK_SPEED, HEIGHT, WIDTH,
 		PADDING, LOOP_OFFSET, MARGIN_FILL, MARGIN, WINDOW_BAR,
 		WINDOW_BAR_SIZE, BORDER_RADIUS, CURSOR_BLINK:

--- a/tty.go
+++ b/tty.go
@@ -24,7 +24,7 @@ func randomPort() int {
 }
 
 // buildTtyCmd builds the ttyd exec.Command on the given port.
-func buildTtyCmd(port int, shell Shell) *exec.Cmd {
+func buildTtyCmd(port int, shell Shell, cwd string) *exec.Cmd {
 	args := []string{
 		fmt.Sprintf("--port=%d", port),
 		"--interface", "127.0.0.1",
@@ -34,6 +34,8 @@ func buildTtyCmd(port int, shell Shell) *exec.Cmd {
 		"-t", "customGlyphs=true",
 		"--once", // will allow one connection and exit
 		"--writable",
+		"--cwd",
+		cwd,
 	}
 
 	args = append(args, shell.Command...)

--- a/vhs.go
+++ b/vhs.go
@@ -179,9 +179,7 @@ func (vhs *VHS) Setup() {
 	// By this point the setting commands have been executed, so the `opts` struct is up to date.
 	vhs.Page.MustEval(fmt.Sprintf("() => { term.options = { fontSize: %d, fontFamily: '%s', letterSpacing: %f, lineHeight: %f, theme: %s, cursorBlink: %t } }",
 			vhs.Options.FontSize, vhs.Options.FontFamily, vhs.Options.LetterSpacing,
-			vhs.Options.LineHeight, vhs.Options.Theme.String(), vhs.Options.CursorBlink,
-		),
-	)
+			vhs.Options.LineHeight, vhs.Options.Theme.String(), vhs.Options.CursorBlink))
 
 	// Fit the terminal into the window
 	vhs.Page.MustEval("term.fit")

--- a/vhs.go
+++ b/vhs.go
@@ -178,8 +178,8 @@ func (vhs *VHS) Setup() {
 	// Apply options to the terminal
 	// By this point the setting commands have been executed, so the `opts` struct is up to date.
 	vhs.Page.MustEval(fmt.Sprintf("() => { term.options = { fontSize: %d, fontFamily: '%s', letterSpacing: %f, lineHeight: %f, theme: %s, cursorBlink: %t } }",
-			vhs.Options.FontSize, vhs.Options.FontFamily, vhs.Options.LetterSpacing,
-			vhs.Options.LineHeight, vhs.Options.Theme.String(), vhs.Options.CursorBlink))
+		vhs.Options.FontSize, vhs.Options.FontFamily, vhs.Options.LetterSpacing,
+		vhs.Options.LineHeight, vhs.Options.Theme.String(), vhs.Options.CursorBlink))
 
 	// Fit the terminal into the window
 	vhs.Page.MustEval("term.fit")

--- a/vhs.go
+++ b/vhs.go
@@ -138,9 +138,7 @@ func (vhs *VHS) Start() error {
 		return fmt.Errorf("could not launch browser: %w", err)
 	}
 	browser := rod.New().ControlURL(u).MustConnect()
-	page, err := browser.Page(
-		proto.TargetCreateTarget{URL: fmt.Sprintf("http://localhost:%d", port)},
-	)
+	page, err := browser.Page(proto.TargetCreateTarget{URL: fmt.Sprintf("http://localhost:%d", port)})
 	if err != nil {
 		return fmt.Errorf("could not open ttyd: %w", err)
 	}
@@ -179,15 +177,9 @@ func (vhs *VHS) Setup() {
 
 	// Apply options to the terminal
 	// By this point the setting commands have been executed, so the `opts` struct is up to date.
-	vhs.Page.MustEval(
-		fmt.Sprintf(
-			"() => { term.options = { fontSize: %d, fontFamily: '%s', letterSpacing: %f, lineHeight: %f, theme: %s, cursorBlink: %t } }",
-			vhs.Options.FontSize,
-			vhs.Options.FontFamily,
-			vhs.Options.LetterSpacing,
-			vhs.Options.LineHeight,
-			vhs.Options.Theme.String(),
-			vhs.Options.CursorBlink,
+	vhs.Page.MustEval(fmt.Sprintf("() => { term.options = { fontSize: %d, fontFamily: '%s', letterSpacing: %f, lineHeight: %f, theme: %s, cursorBlink: %t } }",
+			vhs.Options.FontSize, vhs.Options.FontFamily, vhs.Options.LetterSpacing,
+			vhs.Options.LineHeight, vhs.Options.Theme.String(), vhs.Options.CursorBlink,
 		),
 	)
 


### PR DESCRIPTION
This adds a feature that I've wanted and has been requested by others (#320) is to set the current working directory of the terminal. This is done by using the `Set CWD` options such as

```
Set CWD "/home/user"
```

Because of the way the parser interprets the `/` character the option must be quoted. Includes a check to make sure the directory is valid.