### PR TITLE
Fix app crash when there is repeated SLEEP at the end of the "lines" slice

### DIFF
--- a/record.go
+++ b/record.go
@@ -152,6 +152,9 @@ func inputToTape(input string) string {
 		repeat := 1
 		for lines[i] == lines[i+repeat] {
 			repeat++
+			if i+repeat == len(lines) {
+				break
+			}
 		}
 		i += repeat - 1
 

--- a/record_test.go
+++ b/record_test.go
@@ -66,3 +66,12 @@ func TestInputToTapeLongSleep(t *testing.T) {
 		t.Fatalf("want:\n%s\ngot:\n%s\n", want, got)
 	}
 }
+
+func TestInputToTape_RepeatedSleepAfterExit(t *testing.T) {
+	input := "SLEEP\nexit\nSLEEP\nSLEEP"
+	want := "Sleep 500ms\nType \"exit\"\nSleep 1s\n"
+	got := inputToTape(input)
+	if want != got {
+		t.Fatalf("want:\n%s\ngot:\n%s\n", want, got)
+	}
+}


### PR DESCRIPTION
I found the issue while testing a low value of 5ms for `sleepThreshold`

The goal was to create the same delays as what I actually type.

Here is some related comments ->  
https://news.ycombinator.com/item?id=39298134

Here is the stacktrace you would get without the fix:

```
panic: runtime error: index out of range [634] with length 634

goroutine 1 [running]:
main.inputToTape({0xc0004d8000?, 0xc00014c000?})
	/Users/username/Documents/vhs/record.go:153 +0x15d8
main.Record(0xc000118700?, {0x285e9e0?, 0x4?, 0x1c2156c?})
	/Users/username/Documents/vhs/record.go:117 +0x613
github.com/spf13/cobra.(*Command).execute(0x280c140, {0x285e9e0, 0x0, 0x0})
	/Users/username/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xabc
github.com/spf13/cobra.(*Command).ExecuteC(0x280ccc0)
	/Users/username/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/username/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/Users/username/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032
main.main()
	/Users/username/Documents/vhs/main.go:250 +0xc9
exit status 2
```