### PR TITLE
cmd: add support for `ENV` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,9 +744,9 @@ Paste
 `Env` command sets the environment variable via key-value pair.
 
 ```elixir
-Env KEY "the command is working"
+Env HELLO WORLD
 
-Type "echo $KEY"
+Type "echo $HELLO"
 Enter
 Sleep 3s
 ```

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ There are a few basic types of VHS commands:
 * [`Screenshot`](#screenshot): screenshot the current frame
 * [`Copy/Paste`](#copy--paste): copy and paste text from clipboard.
 * [`Source`](#source): source commands from another tape
+* [`Env <Key> Value`](#env): set environment variables
 
 ### Output
 
@@ -738,6 +739,35 @@ Sleep 500ms
 Paste
 ```
 
+### Env
+
+`Env` command sets the environment variable via key-value pair.
+
+```elixir
+Env KEY "the command is working"
+
+Type "echo $KEY"
+Enter
+Sleep 3s
+```
+
+`Env PROMPT value` changes the command prompt to the given value.
+
+```elixir
+Output examples/demo.gif
+Env PROMPT "Σ"
+
+Require echo
+
+Set Shell "bash"
+Set FontSize 32
+Set Width 1200
+Set Height 600
+
+Type "echo 'Custom prompt'" Sleep 500ms  Enter
+
+Sleep 5s
+```
 
 ### Source
 

--- a/README.md
+++ b/README.md
@@ -751,23 +751,6 @@ Enter
 Sleep 3s
 ```
 
-`Env PROMPT value` changes the command prompt to the given value.
-
-```elixir
-Output examples/demo.gif
-Env PROMPT "Σ"
-
-Require echo
-
-Set Shell "bash"
-Set FontSize 32
-Set Width 1200
-Set Height 600
-
-Type "echo 'Custom prompt'" Sleep 500ms  Enter
-
-Sleep 5s
-```
 
 ### Source
 

--- a/command.go
+++ b/command.go
@@ -253,14 +253,6 @@ func ExecuteCopy(c parser.Command, _ *VHS) {
 func ExecuteEnv(c parser.Command, v *VHS) {
 	_ = os.Setenv(c.Options, c.Args)
 
-	if c.Options == "PROMPT" {
-		if v.Options.Shell.Env != nil {
-			v.Options.Shell.Env[0] = strings.ReplaceAll(v.Options.Shell.Env[0], ">", c.Args)
-		} else if v.Options.Shell.Command != nil {
-			last := len(v.Options.Shell.Command) - 1
-			v.Options.Shell.Command[last] = strings.ReplaceAll(v.Options.Shell.Command[last], ">", c.Args)
-		}
-	}
 }
 
 // ExecutePaste pastes text from the clipboard.

--- a/command.go
+++ b/command.go
@@ -252,7 +252,6 @@ func ExecuteCopy(c parser.Command, _ *VHS) {
 // ExecuteEnv sets env with given key-value pair.
 func ExecuteEnv(c parser.Command, _ *VHS) {
 	_ = os.Setenv(c.Options, c.Args)
-
 }
 
 // ExecutePaste pastes text from the clipboard.

--- a/command.go
+++ b/command.go
@@ -250,7 +250,7 @@ func ExecuteCopy(c parser.Command, _ *VHS) {
 }
 
 // ExecuteEnv sets env with given key-value pair.
-func ExecuteEnv(c parser.Command, v *VHS) {
+func ExecuteEnv(c parser.Command, _ *VHS) {
 	_ = os.Setenv(c.Options, c.Args)
 
 }

--- a/command.go
+++ b/command.go
@@ -64,6 +64,7 @@ var CommandFuncs = map[parser.CommandType]CommandFunc{
 	token.SCREENSHOT: ExecuteScreenshot,
 	token.COPY:       ExecuteCopy,
 	token.PASTE:      ExecutePaste,
+	token.ENV:        ExecuteEnv,
 }
 
 // ExecuteNoop is a no-op command that does nothing.
@@ -246,6 +247,19 @@ func ExecuteOutput(c parser.Command, v *VHS) {
 // ExecuteCopy copies text to the clipboard.
 func ExecuteCopy(c parser.Command, _ *VHS) {
 	_ = clipboard.WriteAll(c.Args)
+}
+
+func ExecuteEnv(c parser.Command, v *VHS) {
+	os.Setenv(c.Options, c.Args)
+
+	if c.Options == "PROMPT" {
+		if v.Options.Shell.Env != nil {
+			v.Options.Shell.Env[0] = strings.ReplaceAll(v.Options.Shell.Env[0], ">", c.Args)
+		} else if v.Options.Shell.Command != nil {
+			last := len(v.Options.Shell.Command) - 1
+			v.Options.Shell.Command[last] = strings.ReplaceAll(v.Options.Shell.Command[last], ">", c.Args)
+		}
+	}
 }
 
 // ExecutePaste pastes text from the clipboard.

--- a/command.go
+++ b/command.go
@@ -249,8 +249,9 @@ func ExecuteCopy(c parser.Command, _ *VHS) {
 	_ = clipboard.WriteAll(c.Args)
 }
 
+// ExecuteEnv sets env with given key-value pair.
 func ExecuteEnv(c parser.Command, v *VHS) {
-	os.Setenv(c.Options, c.Args)
+	_ = os.Setenv(c.Options, c.Args)
 
 	if c.Options == "PROMPT" {
 		if v.Options.Shell.Env != nil {

--- a/command_test.go
+++ b/command_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	const numberOfCommands = 27
+	const numberOfCommands = 28
 	if len(parser.CommandTypes) != numberOfCommands {
 		t.Errorf("Expected %d commands, got %d", numberOfCommands, len(parser.CommandTypes))
 	}
 
-	const numberOfCommandFuncs = 27
+	const numberOfCommandFuncs = 28
 	if len(CommandFuncs) != numberOfCommandFuncs {
 		t.Errorf("Expected %d commands, got %d", numberOfCommandFuncs, len(CommandFuncs))
 	}

--- a/evaluator.go
+++ b/evaluator.go
@@ -32,6 +32,9 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 		if cmd.Type == token.SET && cmd.Options == "Shell" {
 			Execute(cmd, &v)
 		}
+		if cmd.Type == token.ENV {
+			Execute(cmd, &v)
+		}
 	}
 
 	// Start things up

--- a/examples/demo.gif
+++ b/examples/demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d206a3eac29603c4245fabc94bdff26d2656b2f52f740367df18211cb7212e27
-size 21363
+oid sha256:80bae084569563bb4c280062f0f64903b7b45c187cd7a6f2d56d3be62360c47f
+size 25403

--- a/examples/demo.gif
+++ b/examples/demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80bae084569563bb4c280062f0f64903b7b45c187cd7a6f2d56d3be62360c47f
-size 25403
+oid sha256:d2ed6dcd3de32f81b119a45a9d679a1c80eb86ec29f022fb793b1c07b2187c61
+size 15731

--- a/examples/demo.gif
+++ b/examples/demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2ed6dcd3de32f81b119a45a9d679a1c80eb86ec29f022fb793b1c07b2187c61
-size 15731
+oid sha256:d206a3eac29603c4245fabc94bdff26d2656b2f52f740367df18211cb7212e27
+size 21363

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -580,6 +580,10 @@ func (p *Parser) parsePaste() Command {
 	return cmd
 }
 
+// parseEnv parses Env command
+// Env command takes in a key-value pair which is set.
+//
+// Env key "value"
 func (p *Parser) parseEnv() Command {
 	cmd := Command{Type: token.ENV}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -51,6 +51,7 @@ var CommandTypes = []CommandType{ //nolint: deadcode
 	token.SCREENSHOT,
 	token.COPY,
 	token.PASTE,
+	token.ENV,
 }
 
 // String returns the string representation of the command.
@@ -177,6 +178,8 @@ func (p *Parser) parseCommand() Command {
 		return p.parseCopy()
 	case token.PASTE:
 		return p.parsePaste()
+	case token.ENV:
+		return p.parseEnv()
 	default:
 		p.errors = append(p.errors, NewError(p.cur, "Invalid command: "+p.cur.Literal))
 		return Command{Type: token.ILLEGAL}
@@ -574,6 +577,22 @@ func (p *Parser) parseCopy() Command {
 // Paste
 func (p *Parser) parsePaste() Command {
 	cmd := Command{Type: token.PASTE}
+	return cmd
+}
+
+func (p *Parser) parseEnv() Command {
+	cmd := Command{Type: token.ENV}
+
+	cmd.Options = p.peek.Literal
+	p.nextToken()
+
+	if p.peek.Type != token.STRING {
+		p.errors = append(p.errors, NewError(p.peek, p.cur.Literal+" expects string"))
+	}
+
+	cmd.Args = p.peek.Literal
+	p.nextToken()
+
 	return cmd
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -72,6 +72,7 @@ const (
 	COPY            = "COPY"
 	PASTE           = "PASTE"
 	SHELL           = "SHELL"
+	ENV             = "ENV"
 	FONT_FAMILY     = "FONT_FAMILY" //nolint:revive
 	FONT_SIZE       = "FONT_SIZE"   //nolint:revive
 	FRAMERATE       = "FRAMERATE"
@@ -148,6 +149,7 @@ var Keywords = map[string]Type{
 	"Screenshot":    SCREENSHOT,
 	"Copy":          COPY,
 	"Paste":         PASTE,
+	"Env":           ENV,
 }
 
 // IsSetting returns whether a token is a setting.


### PR DESCRIPTION
Implements https://github.com/charmbracelet/vhs/issues/419

![image](https://github.com/charmbracelet/vhs/assets/28479139/a058cad2-4729-4ab1-97c9-128d2f3e9914)


```haskell
Output examples/demo.gif
Env PROMPT "〉"

Require echo

Set Shell "bash"
Set FontSize 32
Set Width 1200
Set Height 600

Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter

Sleep 5s
```

and also allows adding environment variables.

![image](https://github.com/charmbracelet/vhs/assets/28479139/65eb84e0-6b36-4c8a-b474-0ffb03a96e1a)


```haskell
Env TESTING "this works"

Type "echo $TESTING"
Enter
Sleep 3s
```