### PR TITLE
Release ShiftLeft in Shift+Tab

### DIFF
--- a/command.go
+++ b/command.go
@@ -178,7 +178,7 @@ func ExecuteShift(c parser.Command, v *VHS) {
 		}
 	}
 
-	_ = v.Page.Keyboard.Release(input.AltLeft)
+	_ = v.Page.Keyboard.Release(input.ShiftLeft)
 }
 
 // ExecuteHide is a CommandFunc that starts or stops the recording of the vhs.


### PR DESCRIPTION
This fixes a typo in Shift+Tab command. The command was pressing ShiftLeft and releasing AltLeft.