### PR TITLE
record: set VHS_RECORD=true environment variable in process

### DIFF
--- a/record.go
+++ b/record.go
@@ -70,6 +70,8 @@ var EscapeSequences = map[string]string{
 func Record(_ *cobra.Command, _ []string) error {
 	command := exec.Command(shell)
 
+	command.Env = append(command.Env, "VHS_RECORD=true")
+
 	terminal, err := pty.Start(command)
 	if err != nil {
 		return err


### PR DESCRIPTION
Set the environment variable VHS_RECORD=true in the spawned pty command
to allow processes to detect if it is running in a real TTY or in a VHS
recording. Certain TUI libraries query the terminal for feature
detection which can cause issues when running within a VHS pty. Setting this environment variable allows processes to detect if they are running in VHS and enable/disable features as needed.
