### PR TITLE
feat: warn when using `SET` commands not being the top decl

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -152,6 +152,10 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 		//
 		// We should remove if isSetting statement.
 		isSetting := cmd.Type == token.SET && cmd.Options != "TypingSpeed"
+
+		if isSetting {
+			fmt.Println(ErrorStyle.Render(fmt.Sprintf("WARN: Set %s %s has to be a top declaration of the file", cmd.Options, cmd.Args)))
+		}
 		if isSetting || cmd.Type == token.REQUIRE {
 			fmt.Fprintln(out, Highlight(cmd, true))
 			continue

--- a/evaluator.go
+++ b/evaluator.go
@@ -154,7 +154,7 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 		isSetting := cmd.Type == token.SET && cmd.Options != "TypingSpeed"
 
 		if isSetting {
-			fmt.Println(ErrorStyle.Render(fmt.Sprintf("WARN: Set %s %s has to be a top declaration of the file", cmd.Options, cmd.Args)))
+			fmt.Println(ErrorStyle.Render(fmt.Sprintf("WARN: 'Set %s %s' has been ignored. Move the directive to the top of the file.\nLearn more: https://github.com/charmbracelet/vhs#settings", cmd.Options, cmd.Args)))
 		}
 		if isSetting || cmd.Type == token.REQUIRE {
 			fmt.Fprintln(out, Highlight(cmd, true))


### PR DESCRIPTION
This PR adds a warning when using the `SET` commands after the top declaration.

> Agreed, if a setting is ignored we should display a warning that this setting should appear at the top of the file!
> _Originally posted by @maaslalani in https://github.com/charmbracelet/vhs/issues/503#issuecomment-2241697926_