### PR TITLE
feat: don't create 'out.gif' by default

### DIFF
--- a/video.go
+++ b/video.go
@@ -138,11 +138,7 @@ func buildFFopts(opts VideoOptions, targetFile string) []string {
 
 // MakeGIF takes a list of images (as frames) and converts them to a GIF.
 func MakeGIF(opts VideoOptions) *exec.Cmd {
-	targetFile := opts.Output.GIF
-
-	if opts.Output.GIF == "" && opts.Output.WebM == "" && opts.Output.MP4 == "" {
-		targetFile = "out.gif"
-	} else if opts.Output.GIF == "" {
+	if opts.Output.GIF == "" {
 		return nil
 	}
 
@@ -152,7 +148,7 @@ func MakeGIF(opts VideoOptions) *exec.Cmd {
 	//nolint:gosec
 	return exec.Command(
 		"ffmpeg",
-		buildFFopts(opts, targetFile)...,
+		buildFFopts(opts, opts.Output.GIF)...,
 	)
 }
 


### PR DESCRIPTION
If a tape file only asks for text output, e.g., `Output demo.txt`, `vhs` also creates an `out.gif` by default.

This PR removes that behaviour, and only outputs GIF files if `Output <name>.gif` appears in the tape file.