### PR TITLE
chore: fix typo in man output

### DIFF
--- a/man.go
+++ b/man.go
@@ -18,7 +18,7 @@ import (
 const specialChar = "%"
 
 var (
-	manDescription = `VHS let's you write terminal GIFs as code.
+	manDescription = `VHS lets you write terminal GIFs as code.
 VHS reads .tape files and renders GIFs (videos).
 A tape file is a script made up of commands describing what actions to perform in the render.
 


### PR DESCRIPTION
Hi! Thanks for your work on `vhs`; it's a really great tool!

Previously, `vhs man` output text incorrectly using the contraction "let's" (meaning "let us") rather than the verb "lets" (meaning "allows"). This fixes that :)