### PR TITLE
Fix typo in WindowBar parser - fixes #543

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -768,5 +768,5 @@ func (p *Parser) nextToken() {
 func isValidWindowBar(w string) bool {
 	return w == "" ||
 		w == "Colorful" || w == "ColorfulRight" ||
-		w == "Rings" || w == "RightsRight"
+		w == "Rings" || w == "RingsRight"
 }


### PR DESCRIPTION
👋  Hello!

This corrects a typo in the WindowBar parser. fixes #543 

Tested locally:

## Before

```
$ vhs test.tape
File: test.tape
  3 │ Set WindowBar RingsRight
                    ^^^^^^^^^^ RingsRight is not a valid bar style.

parser: 1 error(s)
recording failed
```

## After

```
./vhs ./test.tape
File: ./test.tape
Output .gif demo.gif
Set WindowBar RingsRight
Set FontSize 46
Set Width 1200
Set Height 600
Type echo Welcome to VHS!
Sleep 500ms
Enter 1
Sleep 5s
Creating demo.gif...
Host your GIF on vhs.charm.sh: vhs publish <file>.gif
```

![demo](https://github.com/user-attachments/assets/69771db8-a84c-4fc2-b22a-e526804863aa)
