### PR TITLE
fix(record): propagate env of vhs process to record terminal

### DIFF
--- a/record.go
+++ b/record.go
@@ -70,7 +70,7 @@ var EscapeSequences = map[string]string{
 func Record(_ *cobra.Command, _ []string) error {
 	command := exec.Command(shell)
 
-	command.Env = append(command.Env, "VHS_RECORD=true")
+	command.Env = append(os.Environ(), "VHS_RECORD=true")
 
 	terminal, err := pty.Start(command)
 	if err != nil {


### PR DESCRIPTION
Hello,
This [pr](https://github.com/charmbracelet/vhs/pull/478) broke env variables propagation to terminal spawned by record command.
From Env description
```
	// If Env is nil, the new process uses the current process's
	// environment.

```
Appending `VHS_RECORD` makes it not nil, so it resets env. This pr fixes #554.

For example with the latest released vhs
```
root# echo $HOME
/var/root
root# vhs record
sh-3.2# echo $HOME
sh-3.2# env
VHS_RECORD=true
PWD=/private/var/root
SHLVL=1
_=/usr/bin/env
```
The simplest solution is to get env of the main process and then append `VHS_RECORD` 
The same example with the build from this PR
```
root# echo $HOME
/var/root
root# ./vhs record
sh-3.2# echo $HOME
/var/root

sh-3.2# env
TERM=xterm-ghostty
SHELL=/bin/sh
LC_ALL=en_US.UTF-8
USER=root
SUDO_UID=503
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.4WqxVicPZH/Listeners
__CF_USER_TEXT_ENCODING=0x0:0:0
PATH=/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/REDACTED/go/bin:/Users/REDACTED/.local/share/zinit/polaris/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Applications/Ghostty.app/Contents/MacOS:/Users/REDACTED/Library/Application Support/JetBrains/Toolbox/scripts
MAIL=/var/mail/root
VHS_RECORD=true
PWD=/Users/REDACTED/personal/vhs
LANG=en_US.UTF-8
HOME=/var/root
SUDO_COMMAND=/bin/sh
SHLVL=2
LOGNAME=root
SUDO_GID=20
COLORTERM=truecol
```
Let me know if you see a better solution.