### PR TITLE
feat: Add `TypeVariable` Command for Variable Typing Speed

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	const numberOfCommands = 29
+	const numberOfCommands = 30
 	if len(parser.CommandTypes) != numberOfCommands {
 		t.Errorf("Expected %d commands, got %d", numberOfCommands, len(parser.CommandTypes))
 	}
 
-	const numberOfCommandFuncs = 29
+	const numberOfCommandFuncs = 30
 	if len(CommandFuncs) != numberOfCommandFuncs {
 		t.Errorf("Expected %d commands, got %d", numberOfCommandFuncs, len(CommandFuncs))
 	}

--- a/examples/fixtures/all.tape
+++ b/examples/fixtures/all.tape
@@ -22,6 +22,7 @@ Set TypingSpeed .1
 Set LoopOffset 60.4
 Set LoopOffset 20.99%
 Set CursorBlink false
+Set TypingSpeedVariable 0.1 1s
 
 # Sleep:
 Sleep 1

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -15,6 +15,7 @@ Set Padding 5
 Set CursorBlink false
 Type "echo 'Hello, world!'"
 Enter
+TypeVariable "echo 'Hello, world!'"
 Type@.1 "echo 'Hello, world!'"
 Left 3
 Sleep 1
@@ -45,6 +46,8 @@ Wait+Screen@1m /foobar/`
 		{token.TYPE, "Type"},
 		{token.STRING, "echo 'Hello, world!'"},
 		{token.ENTER, "Enter"},
+		{token.TYPE_VARIABLE, "TypeVariable"},
+		{token.STRING, "echo 'Hello, world!'"},
 		{token.TYPE, "Type"},
 		{token.AT, "@"},
 		{token.NUMBER, ".1"},
@@ -164,6 +167,11 @@ func TestLexTapeFile(t *testing.T) {
 		{token.SET, "Set"},
 		{token.CURSOR_BLINK, "CursorBlink"},
 		{token.BOOLEAN, "false"},
+		{token.SET, "Set"},
+		{token.TYPING_SPEED_VARIABLE, "TypingSpeedVariable"},
+		{token.NUMBER, "0.1"},
+		{token.NUMBER, "1"},
+		{token.SECONDS, "s"},
 		{token.COMMENT, " Sleep:"},
 		{token.SLEEP, "Sleep"},
 		{token.NUMBER, "1"},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -48,6 +48,7 @@ var CommandTypes = []CommandType{ //nolint: deadcode
 	token.SHOW,
 	token.TAB,
 	token.TYPE,
+	token.TYPE_VARIABLE,
 	token.UP,
 	token.WAIT,
 	token.SOURCE,
@@ -155,6 +156,8 @@ func (p *Parser) parseCommand() Command {
 		return p.parseSleep()
 	case token.TYPE:
 		return p.parseType()
+	case token.TYPE_VARIABLE:
+		return p.parseTypeVariable()
 	case token.CTRL:
 		return p.parseCtrl()
 	case token.ALT:
@@ -462,6 +465,29 @@ func (p *Parser) parseSet() Command {
 		} else if cmd.Options == "TypingSpeed" {
 			cmd.Args += "s"
 		}
+	case token.TYPING_SPEED_VARIABLE:
+		firstArg := p.peek.Literal
+		p.nextToken()
+		if p.peek.Type == token.MILLISECONDS || p.peek.Type == token.SECONDS {
+			firstArg += p.peek.Literal
+			p.nextToken()
+		} else {
+			firstArg += "s"
+		}
+
+		var secondArg string
+		if p.peek.Type == token.NUMBER {
+			secondArg = p.peek.Literal
+			p.nextToken()
+			if p.peek.Type == token.MILLISECONDS || p.peek.Type == token.SECONDS {
+				secondArg += p.peek.Literal
+				p.nextToken()
+			} else {
+				secondArg += "s"
+			}
+		}
+
+		cmd.Args = firstArg + " " + secondArg
 	case token.WINDOW_BAR:
 		cmd.Args = p.peek.Literal
 		p.nextToken()
@@ -563,6 +589,39 @@ func (p *Parser) parseShow() Command {
 // Type "string"
 func (p *Parser) parseType() Command {
 	cmd := Command{Type: token.TYPE}
+
+	cmd.Options = p.parseSpeed()
+
+	if p.peek.Type != token.STRING {
+		p.errors = append(p.errors, NewError(p.peek, p.cur.Literal+" expects string"))
+	}
+
+	for p.peek.Type == token.STRING {
+		p.nextToken()
+		cmd.Args += p.cur.Literal
+
+		// If the next token is a string, add a space between them.
+		// Since tokens must be separated by a whitespace, this is most likely
+		// what the user intended.
+		//
+		// Although it is possible that there may be multiple spaces / tabs between
+		// the tokens, however if the user was intending to type multiple spaces
+		// they would need to use a string literal.
+
+		if p.peek.Type == token.STRING {
+			cmd.Args += " "
+		}
+	}
+
+	return cmd
+}
+
+// parseTypeVariable parses a type variable command.
+// A type variable command takes a string to type.
+//
+// TypeVariable "string"
+func (p *Parser) parseTypeVariable() Command {
+	cmd := Command{Type: token.TYPE_VARIABLE}
 
 	cmd.Options = p.parseSpeed()
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -12,6 +12,9 @@ import (
 func TestParser(t *testing.T) {
 	input := `
 Set TypingSpeed 100ms
+Set TypingSpeedVariable 1s 5s
+Set TypingSpeedVariable 0.1 1s
+Set TypingSpeedVariable 1s 2
 Set WaitTimeout 1m
 Set WaitPattern /foo/
 Type "echo 'Hello, World!'"
@@ -37,6 +40,9 @@ Wait@100ms /foobar/`
 
 	expected := []Command{
 		{Type: token.SET, Options: "TypingSpeed", Args: "100ms"},
+		{Type: token.SET, Options: "TypingSpeedVariable", Args: "1s 5s"},
+		{Type: token.SET, Options: "TypingSpeedVariable", Args: "0.1s 1s"},
+		{Type: token.SET, Options: "TypingSpeedVariable", Args: "1s 2s"},
 		{Type: token.SET, Options: "WaitTimeout", Args: "1m"},
 		{Type: token.SET, Options: "WaitPattern", Args: "foo"},
 		{Type: token.TYPE, Options: "", Args: "echo 'Hello, World!'"},
@@ -139,6 +145,7 @@ func TestParseTapeFile(t *testing.T) {
 		{Type: token.SET, Options: "LoopOffset", Args: "60.4%"},
 		{Type: token.SET, Options: "LoopOffset", Args: "20.99%"},
 		{Type: token.SET, Options: "CursorBlink", Args: "false"},
+		{Type: token.SET, Options: "TypingSpeedVariable", Args: "0.1s 1s"},
 		{Type: token.SLEEP, Options: "", Args: "1s"},
 		{Type: token.SLEEP, Options: "", Args: "500ms"},
 		{Type: token.SLEEP, Options: "", Args: ".5s"},

--- a/token/token.go
+++ b/token/token.go
@@ -62,108 +62,112 @@ const (
 	RIGHT = "RIGHT"
 	UP    = "UP"
 
-	HIDE            = "HIDE"
-	OUTPUT          = "OUTPUT"
-	REQUIRE         = "REQUIRE"
-	SET             = "SET"
-	SHOW            = "SHOW"
-	SOURCE          = "SOURCE"
-	TYPE            = "TYPE"
-	SCREENSHOT      = "SCREENSHOT"
-	COPY            = "COPY"
-	PASTE           = "PASTE"
-	SHELL           = "SHELL"
-	ENV             = "ENV"
-	FONT_FAMILY     = "FONT_FAMILY" //nolint:revive
-	FONT_SIZE       = "FONT_SIZE"   //nolint:revive
-	FRAMERATE       = "FRAMERATE"
-	PLAYBACK_SPEED  = "PLAYBACK_SPEED" //nolint:revive
-	HEIGHT          = "HEIGHT"
-	WIDTH           = "WIDTH"
-	LETTER_SPACING  = "LETTER_SPACING" //nolint:revive
-	LINE_HEIGHT     = "LINE_HEIGHT"    //nolint:revive
-	TYPING_SPEED    = "TYPING_SPEED"   //nolint:revive
-	PADDING         = "PADDING"
-	THEME           = "THEME"
-	LOOP_OFFSET     = "LOOP_OFFSET"     //nolint:revive
-	MARGIN_FILL     = "MARGIN_FILL"     //nolint:revive
-	MARGIN          = "MARGIN"          //nolint:revive
-	WINDOW_BAR      = "WINDOW_BAR"      //nolint:revive
-	WINDOW_BAR_SIZE = "WINDOW_BAR_SIZE" //nolint:revive
-	BORDER_RADIUS   = "CORNER_RADIUS"   //nolint:revive
-	WAIT            = "WAIT"            //nolint:revive
-	WAIT_TIMEOUT    = "WAIT_TIMEOUT"    //nolint:revive
-	WAIT_PATTERN    = "WAIT_PATTERN"    //nolint:revive
-	CURSOR_BLINK    = "CURSOR_BLINK"    //nolint:revive
+	HIDE                  = "HIDE"
+	OUTPUT                = "OUTPUT"
+	REQUIRE               = "REQUIRE"
+	SET                   = "SET"
+	SHOW                  = "SHOW"
+	SOURCE                = "SOURCE"
+	TYPE                  = "TYPE"
+	TYPE_VARIABLE         = "TYPE_VARIABLE"
+	SCREENSHOT            = "SCREENSHOT"
+	COPY                  = "COPY"
+	PASTE                 = "PASTE"
+	SHELL                 = "SHELL"
+	ENV                   = "ENV"
+	FONT_FAMILY           = "FONT_FAMILY" //nolint:revive
+	FONT_SIZE             = "FONT_SIZE"   //nolint:revive
+	FRAMERATE             = "FRAMERATE"
+	PLAYBACK_SPEED        = "PLAYBACK_SPEED" //nolint:revive
+	HEIGHT                = "HEIGHT"
+	WIDTH                 = "WIDTH"
+	LETTER_SPACING        = "LETTER_SPACING" //nolint:revive
+	LINE_HEIGHT           = "LINE_HEIGHT"    //nolint:revive
+	TYPING_SPEED          = "TYPING_SPEED"   //nolint:revive
+	TYPING_SPEED_VARIABLE = "TYPING_SPEED_VARIABLE"
+	PADDING               = "PADDING"
+	THEME                 = "THEME"
+	LOOP_OFFSET           = "LOOP_OFFSET"     //nolint:revive
+	MARGIN_FILL           = "MARGIN_FILL"     //nolint:revive
+	MARGIN                = "MARGIN"          //nolint:revive
+	WINDOW_BAR            = "WINDOW_BAR"      //nolint:revive
+	WINDOW_BAR_SIZE       = "WINDOW_BAR_SIZE" //nolint:revive
+	BORDER_RADIUS         = "CORNER_RADIUS"   //nolint:revive
+	WAIT                  = "WAIT"            //nolint:revive
+	WAIT_TIMEOUT          = "WAIT_TIMEOUT"    //nolint:revive
+	WAIT_PATTERN          = "WAIT_PATTERN"    //nolint:revive
+	CURSOR_BLINK          = "CURSOR_BLINK"    //nolint:revive
 )
 
 // Keywords maps keyword strings to tokens.
 var Keywords = map[string]Type{
-	"em":            EM,
-	"px":            PX,
-	"ms":            MILLISECONDS,
-	"s":             SECONDS,
-	"m":             MINUTES,
-	"Set":           SET,
-	"Sleep":         SLEEP,
-	"Type":          TYPE,
-	"Enter":         ENTER,
-	"Space":         SPACE,
-	"Backspace":     BACKSPACE,
-	"Delete":        DELETE,
-	"Insert":        INSERT,
-	"Ctrl":          CTRL,
-	"Alt":           ALT,
-	"Shift":         SHIFT,
-	"Down":          DOWN,
-	"Left":          LEFT,
-	"Right":         RIGHT,
-	"Up":            UP,
-	"PageUp":        PAGEUP,
-	"PageDown":      PAGEDOWN,
-	"Tab":           TAB,
-	"Escape":        ESCAPE,
-	"End":           END,
-	"Hide":          HIDE,
-	"Require":       REQUIRE,
-	"Show":          SHOW,
-	"Output":        OUTPUT,
-	"Shell":         SHELL,
-	"FontFamily":    FONT_FAMILY,
-	"MarginFill":    MARGIN_FILL,
-	"Margin":        MARGIN,
-	"WindowBar":     WINDOW_BAR,
-	"WindowBarSize": WINDOW_BAR_SIZE,
-	"BorderRadius":  BORDER_RADIUS,
-	"FontSize":      FONT_SIZE,
-	"Framerate":     FRAMERATE,
-	"Height":        HEIGHT,
-	"LetterSpacing": LETTER_SPACING,
-	"LineHeight":    LINE_HEIGHT,
-	"PlaybackSpeed": PLAYBACK_SPEED,
-	"TypingSpeed":   TYPING_SPEED,
-	"Padding":       PADDING,
-	"Theme":         THEME,
-	"Width":         WIDTH,
-	"LoopOffset":    LOOP_OFFSET,
-	"WaitTimeout":   WAIT_TIMEOUT,
-	"WaitPattern":   WAIT_PATTERN,
-	"Wait":          WAIT,
-	"Source":        SOURCE,
-	"CursorBlink":   CURSOR_BLINK,
-	"true":          BOOLEAN,
-	"false":         BOOLEAN,
-	"Screenshot":    SCREENSHOT,
-	"Copy":          COPY,
-	"Paste":         PASTE,
-	"Env":           ENV,
+	"em":                  EM,
+	"px":                  PX,
+	"ms":                  MILLISECONDS,
+	"s":                   SECONDS,
+	"m":                   MINUTES,
+	"Set":                 SET,
+	"Sleep":               SLEEP,
+	"Type":                TYPE,
+	"TypeVariable":        TYPE_VARIABLE,
+	"Enter":               ENTER,
+	"Space":               SPACE,
+	"Backspace":           BACKSPACE,
+	"Delete":              DELETE,
+	"Insert":              INSERT,
+	"Ctrl":                CTRL,
+	"Alt":                 ALT,
+	"Shift":               SHIFT,
+	"Down":                DOWN,
+	"Left":                LEFT,
+	"Right":               RIGHT,
+	"Up":                  UP,
+	"PageUp":              PAGEUP,
+	"PageDown":            PAGEDOWN,
+	"Tab":                 TAB,
+	"Escape":              ESCAPE,
+	"End":                 END,
+	"Hide":                HIDE,
+	"Require":             REQUIRE,
+	"Show":                SHOW,
+	"Output":              OUTPUT,
+	"Shell":               SHELL,
+	"FontFamily":          FONT_FAMILY,
+	"MarginFill":          MARGIN_FILL,
+	"Margin":              MARGIN,
+	"WindowBar":           WINDOW_BAR,
+	"WindowBarSize":       WINDOW_BAR_SIZE,
+	"BorderRadius":        BORDER_RADIUS,
+	"FontSize":            FONT_SIZE,
+	"Framerate":           FRAMERATE,
+	"Height":              HEIGHT,
+	"LetterSpacing":       LETTER_SPACING,
+	"LineHeight":          LINE_HEIGHT,
+	"PlaybackSpeed":       PLAYBACK_SPEED,
+	"TypingSpeed":         TYPING_SPEED,
+	"TypingSpeedVariable": TYPING_SPEED_VARIABLE,
+	"Padding":             PADDING,
+	"Theme":               THEME,
+	"Width":               WIDTH,
+	"LoopOffset":          LOOP_OFFSET,
+	"WaitTimeout":         WAIT_TIMEOUT,
+	"WaitPattern":         WAIT_PATTERN,
+	"Wait":                WAIT,
+	"Source":              SOURCE,
+	"CursorBlink":         CURSOR_BLINK,
+	"true":                BOOLEAN,
+	"false":               BOOLEAN,
+	"Screenshot":          SCREENSHOT,
+	"Copy":                COPY,
+	"Paste":               PASTE,
+	"Env":                 ENV,
 }
 
 // IsSetting returns whether a token is a setting.
 func IsSetting(t Type) bool {
 	switch t {
 	case SHELL, FONT_FAMILY, FONT_SIZE, LETTER_SPACING, LINE_HEIGHT,
-		FRAMERATE, TYPING_SPEED, THEME, PLAYBACK_SPEED, HEIGHT, WIDTH,
+		FRAMERATE, TYPING_SPEED, TYPING_SPEED_VARIABLE, THEME, PLAYBACK_SPEED, HEIGHT, WIDTH,
 		PADDING, LOOP_OFFSET, MARGIN_FILL, MARGIN, WINDOW_BAR,
 		WINDOW_BAR_SIZE, BORDER_RADIUS, CURSOR_BLINK, WAIT_TIMEOUT, WAIT_PATTERN:
 		return true

--- a/vhs.go
+++ b/vhs.go
@@ -37,21 +37,27 @@ type VHS struct {
 
 // Options is the set of options for the setup.
 type Options struct {
-	Shell         Shell
-	FontFamily    string
-	FontSize      int
-	LetterSpacing float64
-	LineHeight    float64
-	TypingSpeed   time.Duration
-	Theme         Theme
-	Test          TestOptions
-	Video         VideoOptions
-	LoopOffset    float64
-	WaitTimeout   time.Duration
-	WaitPattern   *regexp.Regexp
-	CursorBlink   bool
-	Screenshot    ScreenshotOptions
-	Style         StyleOptions
+	Shell               Shell
+	FontFamily          string
+	FontSize            int
+	LetterSpacing       float64
+	LineHeight          float64
+	TypingSpeed         time.Duration
+	TypingSpeedVariable TypingSpeedVariableOptions
+	Theme               Theme
+	Test                TestOptions
+	Video               VideoOptions
+	LoopOffset          float64
+	WaitTimeout         time.Duration
+	WaitPattern         *regexp.Regexp
+	CursorBlink         bool
+	Screenshot          ScreenshotOptions
+	Style               StyleOptions
+}
+
+type TypingSpeedVariableOptions struct {
+	MinTypingSpeed time.Duration
+	MaxTypingSpeed time.Duration
 }
 
 const (
@@ -100,13 +106,17 @@ func DefaultVHSOptions() Options {
 		LetterSpacing: defaultLetterSpacing,
 		LineHeight:    defaultLineHeight,
 		TypingSpeed:   defaultTypingSpeed,
-		Shell:         Shells[defaultShell],
-		Theme:         DefaultTheme,
-		CursorBlink:   defaultCursorBlink,
-		Video:         video,
-		Screenshot:    screenshot,
-		WaitTimeout:   defaultWaitTimeout,
-		WaitPattern:   defaultWaitPattern,
+		TypingSpeedVariable: TypingSpeedVariableOptions{
+			MinTypingSpeed: defaultTypingSpeed,
+			MaxTypingSpeed: defaultTypingSpeed,
+		},
+		Shell:       Shells[defaultShell],
+		Theme:       DefaultTheme,
+		CursorBlink: defaultCursorBlink,
+		Video:       video,
+		Screenshot:  screenshot,
+		WaitTimeout: defaultWaitTimeout,
+		WaitPattern: defaultWaitPattern,
 	}
 }
 


### PR DESCRIPTION
## Changes

- Adding in the `TypeVariable` command which types out the given letters in the string, in a variable typing speed,
- The typing speed is determined by setting the `TypingSpeedVariable` option, and providing a min and max typing speed range
- After every keystroke, it would wait randomly within the min and max typing speed range, such that it feels more human,

## Testing Notes
Created `prits.tape`
```
Output prits.gif

Require echo

Set Shell "bash"
Set FontSize 32
Set Width 1200
Set Height 600
Set TypingSpeedVariable 50ms 555ms

Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter
TypeVariable "echo 'Welcome to VHS!'" Sleep 500ms Enter
```

Ran `go run . prits.tape` which produced `prits.gif`

![image](https://github.com/user-attachments/assets/263a6db4-b5ed-4d0f-98df-adcb7b75dd19)

prits.gif showing the second echo command, has multiple pauses after each keystroke, feeling less robotic

![prits](https://github.com/user-attachments/assets/16d5e110-94c0-4899-a827-bfd7dd10e700)





## Other Notes

- Related to https://github.com/charmbracelet/vhs/issues/574

- I considered using another `TypeVariable` command instead of integrating it within `Type` itself. I guess it's easier to keep things separate, instead of multiple options affecting the same `Type` command,
- [ ] Not sure how the `TypeVariable@` would work, would be good to get some direction. Does `TypeVariable@0.1s 2s "blah blah"` be okay
- [ ] I think I'm doing something wrong around `parseTypeVariable`, in the sense of not parsing the `@1s` for indicating speed (i.e. overrides of the speed), Would be cool to get some help/direction on that
- [ ] Is there anything else I'm missing?