### PR TITLE
feat: support additional alt/ctrl/shift special characters

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -42,8 +42,23 @@ func (l *Lexer) NextToken() token.Token {
 	case '=':
 		tok = l.newToken(token.EQUAL, l.ch)
 		l.readChar()
+	case ']':
+		tok = l.newToken(token.RIGHT_BRACKET, l.ch)
+		l.readChar()
+	case '[':
+		tok = l.newToken(token.LEFT_BRACKET, l.ch)
+		l.readChar()
+	case '-':
+		tok = l.newToken(token.MINUS, l.ch)
+		l.readChar()
 	case '%':
 		tok = l.newToken(token.PERCENT, l.ch)
+		l.readChar()
+	case '^':
+		tok = l.newToken(token.CARET, l.ch)
+		l.readChar()
+	case '\\':
+		tok = l.newToken(token.BACKSLASH, l.ch)
 		l.readChar()
 	case '#':
 		tok.Type = token.COMMENT

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -22,6 +22,10 @@ Right@100ms 3
 Sleep 500ms
 Ctrl+C
 Enter
+Ctrl+@
+Ctrl+\
+Alt+]
+Shift+[
 Sleep .1
 Sleep 100ms
 Sleep 2
@@ -65,6 +69,18 @@ Wait+Screen@1m /foobar/`
 		{token.PLUS, "+"},
 		{token.STRING, "C"},
 		{token.ENTER, "Enter"},
+		{token.CTRL, "Ctrl"},
+		{token.PLUS, "+"},
+		{token.AT, "@"},
+		{token.CTRL, "Ctrl"},
+		{token.PLUS, "+"},
+		{token.BACKSLASH, "\\"},
+		{token.ALT, "Alt"},
+		{token.PLUS, "+"},
+		{token.RIGHT_BRACKET, "]"},
+		{token.SHIFT, "Shift"},
+		{token.PLUS, "+"},
+		{token.LEFT_BRACKET, "["},
 		{token.SLEEP, "Sleep"},
 		{token.NUMBER, ".1"},
 		{token.SLEEP, "Sleep"},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -315,6 +315,12 @@ func (p *Parser) parseCtrl() Command {
 		case peek.Type == token.ENTER,
 			peek.Type == token.SPACE,
 			peek.Type == token.BACKSPACE,
+			peek.Type == token.MINUS,
+			peek.Type == token.AT,
+			peek.Type == token.LEFT_BRACKET,
+			peek.Type == token.RIGHT_BRACKET,
+			peek.Type == token.CARET,
+			peek.Type == token.BACKSLASH,
 			peek.Type == token.STRING && len(peek.Literal) == 1:
 			args = append(args, peek.Literal)
 		default:
@@ -344,6 +350,8 @@ func (p *Parser) parseAlt() Command {
 		p.nextToken()
 		if p.peek.Type == token.STRING ||
 			p.peek.Type == token.ENTER ||
+			p.peek.Type == token.LEFT_BRACKET ||
+			p.peek.Type == token.RIGHT_BRACKET ||
 			p.peek.Type == token.TAB {
 			c := p.peek.Literal
 			p.nextToken()
@@ -368,6 +376,8 @@ func (p *Parser) parseShift() Command {
 		p.nextToken()
 		if p.peek.Type == token.STRING ||
 			p.peek.Type == token.ENTER ||
+			p.peek.Type == token.LEFT_BRACKET ||
+			p.peek.Type == token.RIGHT_BRACKET ||
 			p.peek.Type == token.TAB {
 			c := p.peek.Literal
 			p.nextToken()

--- a/token/token.go
+++ b/token/token.go
@@ -17,13 +17,19 @@ type Token struct {
 
 // Tokens for the VHS language
 const (
-	AT      = "@"
-	EQUAL   = "="
-	PLUS    = "+"
-	PERCENT = "%"
-	SLASH   = "/"
-	DOT     = "."
-	DASH    = "-"
+	AT        = "@"
+	EQUAL     = "="
+	PLUS      = "+"
+	PERCENT   = "%"
+	SLASH     = "/"
+	BACKSLASH = "\\"
+	DOT       = "."
+	DASH      = "-"
+
+	MINUS         = "-"
+	RIGHT_BRACKET = "]"
+	LEFT_BRACKET  = "["
+	CARET         = "^"
 
 	EM           = "EM"
 	MILLISECONDS = "MILLISECONDS"

--- a/token/token.go
+++ b/token/token.go
@@ -27,8 +27,8 @@ const (
 	DASH      = "-"
 
 	MINUS         = "-"
-	RIGHT_BRACKET = "]"
-	LEFT_BRACKET  = "["
+	RIGHT_BRACKET = "]" //nolint:revive
+	LEFT_BRACKET  = "[" //nolint:revive
 	CARET         = "^"
 
 	EM           = "EM"


### PR DESCRIPTION
Close #561 

Related https://github.com/charmbracelet/tree-sitter-vhs/pull/23

This PR introduces support to:

```
CTRL+[
CTRL+@
CTRL+^
CTRL+]
CTRL+\
CTRL+-
SHIFT+[
SHIFT+]
ALT+[
ALT+]
```