### PR TITLE
render: Make ffmpeg an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For more examples see the [`examples/`](https://github.com/charmbracelet/vhs/tre
 ## Installation
 
 > [!NOTE]
-> VHS requires [`ttyd`](https://github.com/tsl0922/ttyd) and [`ffmpeg`](https://ffmpeg.org) to be installed and available on your `PATH`.
+> VHS requires [`ttyd`](https://github.com/tsl0922/ttyd) and [`ffmpeg`](https://ffmpeg.org) to be installed and available on your `PATH`, unless only text output is used.
 
 Use a package manager:
 

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -3,8 +3,15 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+)
+
+var (
+	haveFFMpegErr  error
+	haveFFMpegOnce sync.Once
 )
 
 // FilterComplexBuilder generates -filter_complex option of ffmepg.
@@ -14,6 +21,16 @@ type FilterComplexBuilder struct {
 	termWidth     int
 	termHeight    int
 	prevStageName string
+}
+
+func checkFFMpegDependency() error {
+	haveFFMpegOnce.Do(func() {
+		_, ffmpegErr := exec.LookPath("ffmpeg")
+		if ffmpegErr != nil {
+			haveFFMpegErr = fmt.Errorf("ffmpeg is not installed. Install it from: http://ffmpeg.org")
+		}
+	})
+	return haveFFMpegErr
 }
 
 // NewVideoFilterBuilder returns instance of FilterComplexBuilder with video config.

--- a/main.go
+++ b/main.go
@@ -306,10 +306,6 @@ func getVersion(program string) *version.Version {
 // ensureDependencies ensures that all dependencies are correctly installed
 // and versioned before continuing
 func ensureDependencies() error {
-	_, ffmpegErr := exec.LookPath("ffmpeg")
-	if ffmpegErr != nil {
-		return fmt.Errorf("ffmpeg is not installed. Install it from: http://ffmpeg.org")
-	}
 	_, ttydErr := exec.LookPath("ttyd")
 	if ttydErr != nil {
 		return fmt.Errorf("ttyd is not installed. Install it from: https://github.com/tsl0922/ttyd")

--- a/vhs.go
+++ b/vhs.go
@@ -233,6 +233,9 @@ func (vhs *VHS) Render() error {
 		if cmd == nil {
 			continue
 		}
+		if err := checkFFMpegDependency(); err != nil {
+			return err
+		}
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Println(string(out))


### PR DESCRIPTION
As per commit 92db33b ffmpeg is not required anymore by VHS unless some rendering is enabled.

For example we only use VHS as a testing tool and we rely on text output only, so having the whole ffmpeg installed isn't required.

So do this check at rendering time instead of as a pre-requisite