### PR TITLE
ci: fix build

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -3,4 +3,4 @@ package main
 import _ "embed"
 
 //go:embed examples/demo.tape
-var DemoTape []byte
+var demoTape []byte

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/vhs
 
-go 1.23
+go 1.23.0
 
 toolchain go1.24.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/charmbracelet/vhs
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/charmbracelet/vhs
 
-go 1.24.1
+go 1.23
+
+toolchain go1.24.1
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,7 @@ github.com/charmbracelet/bubbletea v1.2.4 h1:KN8aCViA0eps9SCOThb2/XPIlea3ANJLUkv
 github.com/charmbracelet/bubbletea v1.2.4/go.mod h1:Qr6fVQw+wX7JkWWkVyXYk/ZUQ92a6XNekLXa3rR18MM=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
-github.com/charmbracelet/glamour v0.9.1 h1:Q7PdJLOx8EoepsXUvW6Puz5WQ3YUElIGQdYKrIpiGLA=
+github.com/charmbracelet/glamour v0.9.1 h1:11dEfiGP8q1BEqvGoIjivuc2rBk+5qEXdPtaQ2WoiCM=
 github.com/charmbracelet/glamour v0.9.1/go.mod h1:+SHvIS8qnwhgTpVMiXwn7OfGomSqff1cHBCI8jLOetk=
 github.com/charmbracelet/keygen v0.5.3 h1:2MSDC62OUbDy6VmjIE2jM24LuXUvKywLCmaJDmr/Z/4=
 github.com/charmbracelet/keygen v0.5.3/go.mod h1:TcpNoMAO5GSmhx3SgcEMqCrtn8BahKhB8AlwnLjRUpk=

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ var (
 				return err
 			}
 
-			_, err = f.Write(bytes.Replace(DemoTape, []byte("examples/demo.gif"), []byte(name+".gif"), 1))
+			_, err = f.Write(bytes.Replace(demoTape, []byte("examples/demo.gif"), []byte(name+".gif"), 1))
 			if err != nil {
 				return err
 			}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -302,7 +302,7 @@ func (st *parseSourceTest) run(t *testing.T) {
 	if st.writeFile {
 		err := os.WriteFile("source.tape", []byte(st.srcTape), os.ModePerm)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		}
 	}
 

--- a/serve_windows.go
+++ b/serve_windows.go
@@ -4,6 +4,6 @@
 package main
 
 // Windows doesn't support UID and GID, so we need to skip this.
-func dropUserPrivileges(gid int, uid int) error {
+func dropUserPrivileges(int, int) error {
 	return nil
 }


### PR DESCRIPTION
so, apparently, since I don't know when, having GOPRIVATE set might make `go get` resolve to a bad sha? 

i don't get why this is happening, but figured out it happened on all my machines because all of them had this env set to `github.com/charmbracelet/`. 

anyway, github actions was resolving correctly apparently.