### PR TITLE
Add text screenshot capability to Screenshot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,12 +756,18 @@ Type "You will see this being typed."
 
 ### Screenshot
 
-The `Screenshot` command captures the current frame (png format).
+The `Screenshot` command captures the current frame in either PNG or text format.
 
 ```elixir
-# At any point...
+# Capture as PNG image
 Screenshot examples/screenshot.png
+
+# Capture as plain text
+Screenshot examples/screenshot.txt
 ```
+
+When using `.png` extension, VHS captures a visual screenshot of the terminal.
+When using `.txt` extension, VHS captures the terminal content as plain text without any styling.
 
 ### Copy / Paste
 

--- a/examples/text-screenshot.tape
+++ b/examples/text-screenshot.tape
@@ -1,0 +1,21 @@
+Output test_output.gif
+
+Set FontSize 20
+Set Width 800 
+Set Height 400
+
+Type "echo 'Hello World'"
+Enter
+Sleep 0.5s
+
+Screenshot test_screenshot.txt
+
+Sleep 0.5s
+
+Type "ls -la"
+Enter
+Sleep 1s
+
+Screenshot test_screenshot2.png
+Sleep 0.1s
+Screenshot test_screenshot2.txt

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -755,10 +755,10 @@ func (p *Parser) parseScreenshot() Command {
 
 	path := p.peek.Literal
 
-	// Check if path has .png extension
+	// Check if path has .png or .txt extension
 	ext := filepath.Ext(path)
-	if ext != ".png" {
-		p.errors = append(p.errors, NewError(p.peek, "Expected file with .png extension"))
+	if ext != ".png" && ext != ".txt" {
+		p.errors = append(p.errors, NewError(p.peek, "Expected file with .png or .txt extension"))
 		p.nextToken()
 		return cmd
 	}

--- a/screenshot.go
+++ b/screenshot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 )
@@ -17,6 +18,9 @@ type ScreenshotOptions struct {
 	// screenshots represents a map holding screenshot path as key and frame as value.
 	screenshots map[string]int
 
+	// textScreenshots represents a map holding text screenshot path as key and content as value.
+	textScreenshots map[string]string
+
 	// Input represents location of cursor and text frames png files.
 	input string
 
@@ -29,6 +33,7 @@ func NewScreenshotOptions(input string, style *StyleOptions) ScreenshotOptions {
 		frameCapture:       false,
 		nextScreenshotPath: "",
 		screenshots:        make(map[string]int),
+		textScreenshots:    make(map[string]string),
 		input:              input,
 		style:              style,
 	}
@@ -38,6 +43,15 @@ func NewScreenshotOptions(input string, style *StyleOptions) ScreenshotOptions {
 // After storing frame it disables frame capture.
 func (opts *ScreenshotOptions) makeScreenshot(frame int) {
 	opts.screenshots[opts.nextScreenshotPath] = frame
+
+	opts.frameCapture = false
+	opts.nextScreenshotPath = ""
+}
+
+// makeTextScreenshot stores text content for a text screenshot.
+// After storing content it disables frame capture.
+func (opts *ScreenshotOptions) makeTextScreenshot(content string) {
+	opts.textScreenshots[opts.nextScreenshotPath] = content
 
 	opts.frameCapture = false
 	opts.nextScreenshotPath = ""
@@ -54,6 +68,12 @@ func MakeScreenshots(opts ScreenshotOptions) []*exec.Cmd {
 	cmds := []*exec.Cmd{}
 
 	for path, frame := range opts.screenshots {
+		// Handle text format screenshots differently
+		if filepath.Ext(path) == ".txt" {
+			// Text screenshots don't need ffmpeg, they'll be handled elsewhere
+			continue
+		}
+
 		cursorStream := filepath.Join(opts.input, fmt.Sprintf(cursorFrameFormat, frame))
 		textStream := filepath.Join(opts.input, fmt.Sprintf(textFrameFormat, frame))
 
@@ -98,4 +118,16 @@ func (opts *ScreenshotOptions) buildFFopts(targetFile, textStream, cursorStream 
 	args = append(args, targetFile)
 
 	return args
+}
+
+// MakeTextScreenshots writes text screenshots that were captured during recording.
+func MakeTextScreenshots(opts ScreenshotOptions) error {
+	for path, content := range opts.textScreenshots {
+		// Write to file
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("failed to write text screenshot to %s: %w", path, err)
+		}
+	}
+
+	return nil
 }

--- a/screenshot_test.go
+++ b/screenshot_test.go
@@ -45,4 +45,18 @@ func TestScreenshot(t *testing.T) {
 			t.Errorf("nextScreenshotPath: %s, expected: %s", opts.nextScreenshotPath, path)
 		}
 	})
+
+	t.Run("MakeTextScreenshots should process text screenshots", func(t *testing.T) {
+		opts := ScreenshotOptions{
+			textScreenshots: map[string]string{
+				"test.txt": "Hello World\nLine 2",
+			},
+		}
+
+		// This should not error because we're just writing files
+		err := MakeTextScreenshots(opts)
+		if err != nil {
+			t.Errorf("Expected no error when processing text screenshots, got: %v", err)
+		}
+	})
 }

--- a/vhs.go
+++ b/vhs.go
@@ -227,6 +227,11 @@ func (vhs *VHS) Render() error {
 	}
 
 	// Generate the video(s) with the frames.
+	// Generate text screenshots first
+	if err := MakeTextScreenshots(vhs.Options.Screenshot); err != nil {
+		return fmt.Errorf("failed to create text screenshots: %w", err)
+	}
+
 	var cmds []*exec.Cmd
 	cmds = append(cmds, MakeGIF(vhs.Options.Video))
 	cmds = append(cmds, MakeMP4(vhs.Options.Video))
@@ -378,7 +383,19 @@ func (vhs *VHS) Record(ctx context.Context) <-chan error {
 
 				// Capture current frame and disable frame capturing
 				if vhs.Options.Screenshot.frameCapture {
-					vhs.Options.Screenshot.makeScreenshot(counter)
+					// Check if this is a text screenshot
+					if filepath.Ext(vhs.Options.Screenshot.nextScreenshotPath) == ".txt" {
+						// Get terminal buffer content
+						buffer, err := vhs.Buffer()
+						if err != nil {
+							ch <- fmt.Errorf("error capturing text screenshot: %w", err)
+							continue
+						}
+						content := strings.Join(buffer, "\n")
+						vhs.Options.Screenshot.makeTextScreenshot(content)
+					} else {
+						vhs.Options.Screenshot.makeScreenshot(counter)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Extends the `Screenshot` command to support capturing terminal content as 
plain text in addition to the existing PNG image format.

## Usage

```
# Capture visual screenshot
Screenshot output.png

# Capture text content
Screenshot output.txt
```