### PR TITLE
Add pixi to supported package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ nix-env -iA nixpkgs.vhs
 
 # Windows using scoop
 scoop install vhs
+
+# Conda-forge
+pixi global install vhs
 ```
 
 Or, use Docker to run VHS directly, dependencies included:


### PR DESCRIPTION
### Describe your changes

[pixi](https://pixi.sh) is a modern package manager for the conda ecosystem that works on macOS, Linux and Windows.
Vhs is also packaged on conda-forge: https://prefix.dev/channels/conda-forge/packages/vhs

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
