### PR TITLE
fix: capture visible viewport in `VHS.Buffer`

### DIFF
--- a/command.go
+++ b/command.go
@@ -144,9 +144,9 @@ func ExecuteWait(c parser.Command, v *VHS) error {
 				return nil
 			}
 		case "Screen":
-			lines, err := v.Buffer()
+			lines, err := v.VisibleLines()
 			if err != nil {
-				return fmt.Errorf("failed to get buffer: %w", err)
+				return fmt.Errorf("failed to get visible lines: %w", err)
 			}
 			last = strings.Join(lines, "\n")
 

--- a/testing.go
+++ b/testing.go
@@ -44,7 +44,7 @@ func (v *VHS) SaveOutput() error {
 		return fmt.Errorf("failed to create output file: %w", err)
 	}
 
-	lines, err := v.Buffer()
+	lines, err := v.VisibleLines()
 	if err != nil {
 		return fmt.Errorf("failed to get buffer: %w", err)
 	}
@@ -64,8 +64,8 @@ func (v *VHS) SaveOutput() error {
 	return nil
 }
 
-// Buffer returns the visible lines from the terminal's viewport.
-func (v *VHS) Buffer() ([]string, error) {
+// VisibleLines returns the visible lines from the terminal's viewport.
+func (v *VHS) VisibleLines() ([]string, error) {
 	// Capture the visible lines from the terminal.
 	buf, err := v.Page.Eval("() => Array.from({ length: term.rows }, (_, i) => term.buffer.active.getLine(i + term.buffer.active.viewportY).translateToString().trimEnd())")
 	if err != nil {


### PR DESCRIPTION
### Describe your changes

The `VHS.Buffer` method was incorrectly reading from the top of the scrollback buffer.

This causes issues when using the [`Wait+Screen /regex/` command](https://github.com/charmbracelet/vhs?tab=readme-ov-file#wait), and when writing output to [golden files](https://github.com/charmbracelet/vhs?tab=readme-ov-file#continuous-integration).

The logic now accounts for the scroll position (`viewportY`) to capture *visible* lines in the terminal viewport as expected.

More details in the issues linked below (which both include the output after this change in the "Expected Behavior" sections, as well as steps to reproduce the current unexpected behavior).

#### Additional Style Changes

  * Prefer blank identifier for unused variable.
  * Replaced `fill().map()` with `Array.from()` for clarity.
  * Renamed the method `CurrentLines` and updated comments for clarity and accuracy.

### Related issue/discussion
Closes https://github.com/charmbracelet/vhs/issues/657, closes https://github.com/charmbracelet/vhs/issues/659

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
