### PR TITLE
Improve Faint style

### DIFF
--- a/style.go
+++ b/style.go
@@ -40,7 +40,7 @@ const (
 // Styles for syntax highlightin.
 var (
 	CommandStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
-	FaintStyle      = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "242", Dark: "238"})
+	FaintStyle      = lipgloss.NewStyle().Faint(true)
 	NoneStyle       = lipgloss.NewStyle()
 	KeywordStyle    = lipgloss.NewStyle()
 	URLStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))


### PR DESCRIPTION
Use the libgloss `Faint` style, which uses the ANSI escape sequence for "faint" (or "dim"). The previously used `AdaptiveColor` was hardly visible on dark terminal backgrounds.