### PR TITLE
docs[readme]: add note about inline comments in tape file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Tape files consist of a series of [commands](#vhs-command-reference). The comman
 instructions for VHS to perform on its virtual terminal. For a list of all
 possible commands see [the command reference](#vhs-command-reference).
 
+> [!NOTE]
+> You can include inline comments in your tape file by starting a line with `#`.
+
 ```elixir
 # Where should we write the GIF?
 Output demo.gif


### PR DESCRIPTION
This is a very minor README update to add an explicit note to ensure users know comments are allowed in tape files. I saw this reported in https://github.com/charmbracelet/vhs/discussions/608 and figure I could add it here.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
~~- [ ] I have created a discussion that was approved by a maintainer (for new features).~~
