### PR TITLE
feat[playback]: add per-section playback speed control

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ There are a few basic types of VHS commands:
 - [`ScrollUp`](#scroll-up--down) [`ScrollDown`](#scroll-up--down): scroll terminal viewport
 - [`Ctrl[+Alt][+Shift]+<char>`](#ctrl): press control + key and/or modifier
 - [`Sleep <time>`](#sleep): wait for a certain amount of time
+- [`Playback@<speed>`](#playback): change playback speed for subsequent commands
 - [`Wait[+Screen][+Line] /regex/`](#wait): wait for specific conditions
 - [`Hide`](#hide): hide commands from output
 - [`Show`](#show): stop hiding commands from output
@@ -496,12 +497,32 @@ Set Framerate 60
 
 #### Set Playback Speed
 
-Set the playback speed of the final render.
+Set the global playback speed of the final render.
 
 ```elixir
 Set PlaybackSpeed 0.5 # Make output 2 times slower
 Set PlaybackSpeed 1.0 # Keep output at normal speed (default)
 Set PlaybackSpeed 2.0 # Make output 2 times faster
+```
+
+### Playback
+
+Set the playback speed for subsequent sections or commands. Unlike `Set PlaybackSpeed` which applies globally to the entire output, `Playback@` lets you vary the speed at different points in your recording.
+
+```elixir
+Type "Normal speed here"
+
+Playback@2
+# This renders at 2x speed
+Type "SlowCommand"
+Enter
+Sleep 1s
+
+Playback@0.5
+Type "This plays in slow motion"
+
+Playback@1
+Type "Back to normal speed"
 ```
 
 #### Set Loop Offset

--- a/command.go
+++ b/command.go
@@ -70,6 +70,7 @@ var CommandFuncs = map[parser.CommandType]CommandFunc{
 	token.PASTE:       ExecutePaste,
 	token.ENV:         ExecuteEnv,
 	token.WAIT:        ExecuteWait,
+	token.PLAYBACK:    ExecutePlayback,
 }
 
 // ExecuteNoop is a no-op command that does nothing.
@@ -369,6 +370,16 @@ func ExecuteSleep(c parser.Command, _ *VHS) error {
 		return fmt.Errorf("failed to parse duration: %w", err)
 	}
 	time.Sleep(dur)
+	return nil
+}
+
+// ExecutePlayback records a playback speed section boundary at the current frame.
+func ExecutePlayback(c parser.Command, v *VHS) error {
+	speed, err := strconv.ParseFloat(c.Args, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse playback speed: %w", err)
+	}
+	v.AddPlaybackSection(speed)
 	return nil
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	const numberOfCommands = 31
+	const numberOfCommands = 32
 	if len(parser.CommandTypes) != numberOfCommands {
 		t.Errorf("Expected %d commands, got %d", numberOfCommands, len(parser.CommandTypes))
 	}
 
-	const numberOfCommandFuncs = 31
+	const numberOfCommandFuncs = 32
 	if len(CommandFuncs) != numberOfCommandFuncs {
 		t.Errorf("Expected %d commands, got %d", numberOfCommandFuncs, len(CommandFuncs))
 	}

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -21,28 +21,45 @@ func NewVideoFilterBuilder(videoOpts *VideoOptions) *FilterComplexBuilder {
 	filterCode := strings.Builder{}
 	termWidth, termHeight := calcTermDimensions(*videoOpts.Style)
 
-	_, _ = fmt.Fprintf(&filterCode, `
+	// Base overlay and scale
+	filterCode.WriteString(
+		fmt.Sprintf(`
 		[0][1]overlay[merged];
-		[merged]scale=%d:%d:force_original_aspect_ratio=1[scaled];
-		[scaled]fps=%d,setpts=PTS/%f[speed];
+		[merged]scale=%d:%d:force_original_aspect_ratio=1[scaled]`,
+			termWidth-double(videoOpts.Style.Padding),
+			termHeight-double(videoOpts.Style.Padding),
+		),
+	)
+
+	// Apply speed: either uniform or per-section
+	if len(videoOpts.PlaybackSections) > 0 {
+		buildPlaybackSections(&filterCode, videoOpts)
+	} else {
+		filterCode.WriteString(
+			fmt.Sprintf(`;
+		[scaled]fps=%d,setpts=PTS/%f[speed]`,
+				videoOpts.Framerate,
+				videoOpts.PlaybackSpeed,
+			),
+		)
+	}
+
+	// Padding and borders
+	filterCode.WriteString(
+		fmt.Sprintf(`;
 		[speed]pad=%d:%d:(ow-iw)/2:(oh-ih)/2:%s[padded];
 		[padded]fillborders=left=%d:right=%d:top=%d:bottom=%d:mode=fixed:color=%s[padded]
 		`,
-		termWidth-double(videoOpts.Style.Padding),
-		termHeight-double(videoOpts.Style.Padding),
+			termWidth,
+			termHeight,
+			videoOpts.Style.BackgroundColor,
 
-		videoOpts.Framerate,
-		videoOpts.PlaybackSpeed,
-
-		termWidth,
-		termHeight,
-		videoOpts.Style.BackgroundColor,
-
-		videoOpts.Style.Padding,
-		videoOpts.Style.Padding,
-		videoOpts.Style.Padding,
-		videoOpts.Style.Padding,
-		videoOpts.Style.BackgroundColor,
+			videoOpts.Style.Padding,
+			videoOpts.Style.Padding,
+			videoOpts.Style.Padding,
+			videoOpts.Style.Padding,
+			videoOpts.Style.BackgroundColor,
+		),
 	)
 
 	return &FilterComplexBuilder{
@@ -52,6 +69,48 @@ func NewVideoFilterBuilder(videoOpts *VideoOptions) *FilterComplexBuilder {
 		style:         videoOpts.Style,
 		prevStageName: "padded",
 	}
+}
+
+// buildPlaybackSections generates FFmpeg filter for variable playback speed.
+func buildPlaybackSections(filterCode *strings.Builder, opts *VideoOptions) {
+	sections := opts.PlaybackSections
+	n := len(sections)
+	framerate := opts.Framerate
+
+	// Apply fps first
+	filterCode.WriteString(fmt.Sprintf(`;
+		[scaled]fps=%d[fpsout]`, framerate))
+
+	// Split into n streams
+	filterCode.WriteString(fmt.Sprintf(`;
+		[fpsout]split=%d`, n))
+	for i := 0; i < n; i++ {
+		filterCode.WriteString(fmt.Sprintf("[s%d]", i))
+	}
+
+	// Process each section with trim and speed adjustment
+	for i, section := range sections {
+		startTime := float64(section.StartFrame) / float64(framerate)
+
+		// Calculate end time: next section's start or use a large value for last section
+		var endTime float64
+		if i < n-1 {
+			endTime = float64(sections[i+1].StartFrame) / float64(framerate)
+		} else {
+			// Last section extends to the end (use large value, ffmpeg will handle EOF)
+			endTime = 86400.0 // 24 hours, effectively unlimited
+		}
+
+		filterCode.WriteString(fmt.Sprintf(`;
+		[s%d]trim=start=%f:end=%f,setpts=PTS-STARTPTS,setpts=PTS/%f[v%d]`,
+			i, startTime, endTime, section.Speed, i))
+	}
+
+	// Concat all sections
+	for i := 0; i < n; i++ {
+		filterCode.WriteString(fmt.Sprintf("[v%d]", i))
+	}
+	filterCode.WriteString(fmt.Sprintf("concat=n=%d:v=1:a=0[speed]", n))
 }
 
 // NewScreenshotFilterComplexBuilder returns instance of FilterComplexBuilder with screenshot config.

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -34,7 +34,10 @@ Sleep 2
 Wait+Screen@1m /foobar/
 Wait+Screen@1m /foo\/bar/
 Wait+Screen@1m /foo\\/
-Wait+Screen@1m /foo\\\/bar/`
+Wait+Screen@1m /foo\\\/bar/
+Playback@2.0
+Playback@0.5
+Playback@1`
 
 	tests := []struct {
 		expectedType    token.Type
@@ -128,6 +131,15 @@ Wait+Screen@1m /foo\\\/bar/`
 		{token.NUMBER, "1"},
 		{token.MINUTES, "m"},
 		{token.REGEX, "foo\\\\\\/bar"},
+		{token.PLAYBACK, "Playback"},
+		{token.AT, "@"},
+		{token.NUMBER, "2.0"},
+		{token.PLAYBACK, "Playback"},
+		{token.AT, "@"},
+		{token.NUMBER, "0.5"},
+		{token.PLAYBACK, "Playback"},
+		{token.AT, "@"},
+		{token.NUMBER, "1"},
 	}
 
 	l := New(input)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -58,6 +58,7 @@ var CommandTypes = []CommandType{
 	token.COPY,
 	token.PASTE,
 	token.ENV,
+	token.PLAYBACK,
 }
 
 // String returns the string representation of the command.
@@ -185,6 +186,8 @@ func (p *Parser) parseCommand() []Command {
 		return []Command{p.parsePaste()}
 	case token.ENV:
 		return []Command{p.parseEnv()}
+	case token.PLAYBACK:
+		return []Command{p.parsePlayback()}
 	default:
 		p.errors = append(p.errors, NewError(p.cur, "Invalid command: "+p.cur.Literal))
 		return []Command{{Type: token.ILLEGAL}}
@@ -539,6 +542,42 @@ func (p *Parser) parseSet() Command {
 func (p *Parser) parseSleep() Command {
 	cmd := Command{Type: token.SLEEP}
 	cmd.Args = p.parseTime()
+	return cmd
+}
+
+// parsePlayback parses a Playback command.
+// A playback command uses @<number> syntax to set playback speed multiplier.
+//
+//	Playback@<number>
+func (p *Parser) parsePlayback() Command {
+	cmd := Command{Type: token.PLAYBACK}
+
+	if p.peek.Type != token.AT {
+		p.errors = append(p.errors, NewError(p.cur, "Expected @ after Playback"))
+		return cmd
+	}
+	p.nextToken()
+
+	if p.peek.Type != token.NUMBER {
+		p.errors = append(p.errors, NewError(p.cur, "Expected number after Playback@"))
+		return cmd
+	}
+
+	speed, err := strconv.ParseFloat(p.peek.Literal, 64)
+	if err != nil {
+		p.errors = append(p.errors, NewError(p.peek, "Invalid playback speed: "+p.peek.Literal))
+		p.nextToken()
+		return cmd
+	}
+
+	if speed <= 0 {
+		p.errors = append(p.errors, NewError(p.peek, "Playback speed must be positive"))
+		p.nextToken()
+		return cmd
+	}
+
+	cmd.Args = p.peek.Literal
+	p.nextToken()
 	return cmd
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -35,7 +35,10 @@ Sleep 100ms
 Sleep 3
 Wait
 Wait+Screen
-Wait@100ms /foobar/`
+Wait@100ms /foobar/
+Playback@2.0
+Playback@0.5
+Playback@1`
 
 	expected := []Command{
 		{Type: token.SET, Options: "TypingSpeed", Args: "100ms"},
@@ -63,6 +66,9 @@ Wait@100ms /foobar/`
 		{Type: token.WAIT, Args: "Line"},
 		{Type: token.WAIT, Args: "Screen"},
 		{Type: token.WAIT, Options: "100ms", Args: "Line foobar"},
+		{Type: token.PLAYBACK, Args: "2.0"},
+		{Type: token.PLAYBACK, Args: "0.5"},
+		{Type: token.PLAYBACK, Args: "1"},
 	}
 
 	l := lexer.New(input)
@@ -479,5 +485,37 @@ func TestParseScreeenshot(t *testing.T) {
 		}
 
 		test.run(t)
+	})
+}
+
+func TestParsePlayback(t *testing.T) {
+	t.Run("valid playback commands", func(t *testing.T) {
+		l := lexer.New("Playback@2.0")
+		p := New(l)
+		cmds := p.Parse()
+		if len(p.errors) > 0 {
+			t.Errorf("expected no errors, got %v", p.errors)
+		}
+		if len(cmds) != 1 || cmds[0].Type != token.PLAYBACK || cmds[0].Args != "2.0" {
+			t.Errorf("expected Playback command with args 2.0, got %v", cmds)
+		}
+	})
+
+	t.Run("missing @ symbol", func(t *testing.T) {
+		l := lexer.New("Playback 2.0")
+		p := New(l)
+		_ = p.Parse()
+		if len(p.errors) == 0 {
+			t.Error("expected error for missing @")
+		}
+	})
+
+	t.Run("zero speed", func(t *testing.T) {
+		l := lexer.New("Playback@0")
+		p := New(l)
+		_ = p.Parse()
+		if len(p.errors) == 0 {
+			t.Error("expected error for zero speed")
+		}
 	})
 }

--- a/syntax.go
+++ b/syntax.go
@@ -59,6 +59,8 @@ func Highlight(c parser.Command, faint bool) string {
 	case token.TYPE:
 		optionsStyle = TimeStyle
 		argsStyle = StringStyle
+	case token.PLAYBACK:
+		argsStyle = NumberStyle
 	case token.HIDE, token.SHOW:
 		return FaintStyle.Render(c.Type.String())
 	}

--- a/token/token.go
+++ b/token/token.go
@@ -57,6 +57,7 @@ const (
 	SCROLL_UP   = "SCROLL_UP"
 	SLEEP       = "SLEEP"
 	SPACE       = "SPACE"
+	PLAYBACK    = "PLAYBACK"
 	TAB         = "TAB"
 	SHIFT       = "SHIFT"
 
@@ -162,6 +163,7 @@ var Keywords = map[string]Type{
 	"WaitPattern":   WAIT_PATTERN,
 	"Wait":          WAIT,
 	"Source":        SOURCE,
+	"Playback":      PLAYBACK,
 	"CursorBlink":   CURSOR_BLINK,
 	"true":          BOOLEAN,
 	"false":         BOOLEAN,
@@ -187,7 +189,7 @@ func IsSetting(t Type) bool {
 // IsCommand returns whether the string is a command.
 func IsCommand(t Type) bool {
 	switch t {
-	case TYPE, SLEEP,
+	case TYPE, SLEEP, PLAYBACK,
 		UP, DOWN, RIGHT, LEFT, PAGE_UP, PAGE_DOWN, SCROLL_UP, SCROLL_DOWN,
 		ENTER, BACKSPACE, DELETE, TAB,
 		ESCAPE, HOME, INSERT, END, CTRL, SOURCE, SCREENSHOT, COPY, PASTE, WAIT:

--- a/vhs.go
+++ b/vhs.go
@@ -431,10 +431,23 @@ func (vhs *VHS) AddPlaybackSection(speed float64) {
 }
 
 // FinalizePlaybackSections copies playback sections to VideoOptions for rendering.
+// It prepends an initial section from the start to the first playback command.
 func (vhs *VHS) FinalizePlaybackSections() {
 	vhs.mutex.Lock()
 	defer vhs.mutex.Unlock()
-	if len(vhs.playbackSections) > 0 {
-		vhs.Options.Video.PlaybackSections = vhs.playbackSections
+	if len(vhs.playbackSections) == 0 {
+		return
 	}
+
+	// Prepend initial section from start to first playback command
+	finalSections := make([]PlaybackSection, 0, len(vhs.playbackSections)+1)
+	if vhs.playbackSections[0].StartFrame > vhs.Options.Video.StartingFrame {
+		// Add initial section with default speed
+		finalSections = append(finalSections, PlaybackSection{
+			StartFrame: vhs.Options.Video.StartingFrame,
+			Speed:      vhs.Options.Video.PlaybackSpeed,
+		})
+	}
+	finalSections = append(finalSections, vhs.playbackSections...)
+	vhs.Options.Video.PlaybackSections = finalSections
 }

--- a/vhs.go
+++ b/vhs.go
@@ -21,18 +21,20 @@ import (
 
 // VHS is the object that controls the setup.
 type VHS struct {
-	Options      *Options
-	Errors       []error
-	Page         *rod.Page
-	browser      *rod.Browser
-	TextCanvas   *rod.Element
-	CursorCanvas *rod.Element
-	mutex        *sync.Mutex
-	started      bool
-	recording    bool
-	tty          *exec.Cmd
-	totalFrames  int
-	close        func() error
+	Options          *Options
+	Errors           []error
+	Page             *rod.Page
+	browser          *rod.Browser
+	TextCanvas       *rod.Element
+	CursorCanvas     *rod.Element
+	mutex            *sync.Mutex
+	started          bool
+	recording        bool
+	tty              *exec.Cmd
+	totalFrames      int
+	currentFrame     int
+	playbackSections []PlaybackSection
+	close            func() error
 }
 
 // Options is the set of options for the setup.
@@ -226,6 +228,9 @@ func (vhs *VHS) Render() error {
 		return err
 	}
 
+	// Copy playback sections to video options for rendering
+	vhs.FinalizePlaybackSections()
+
 	// Generate the video(s) with the frames.
 	var cmds []*exec.Cmd //nolint:prealloc
 	cmds = append(cmds, MakeGIF(vhs.Options.Video))
@@ -359,6 +364,10 @@ func (vhs *VHS) Record(ctx context.Context) <-chan error {
 				}
 
 				counter++
+				vhs.mutex.Lock()
+				vhs.currentFrame = counter
+				vhs.mutex.Unlock()
+
 				if err := os.WriteFile(
 					filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(cursorFrameFormat, counter)),
 					cursor,
@@ -409,4 +418,23 @@ func (vhs *VHS) ScreenshotNextFrame(path string) {
 	defer vhs.mutex.Unlock()
 
 	vhs.Options.Screenshot.enableFrameCapture(path)
+}
+
+// AddPlaybackSection records a playback section boundary at the current frame.
+func (vhs *VHS) AddPlaybackSection(speed float64) {
+	vhs.mutex.Lock()
+	defer vhs.mutex.Unlock()
+	vhs.playbackSections = append(vhs.playbackSections, PlaybackSection{
+		StartFrame: vhs.currentFrame,
+		Speed:      speed,
+	})
+}
+
+// FinalizePlaybackSections copies playback sections to VideoOptions for rendering.
+func (vhs *VHS) FinalizePlaybackSections() {
+	vhs.mutex.Lock()
+	defer vhs.mutex.Unlock()
+	if len(vhs.playbackSections) > 0 {
+		vhs.Options.Video.PlaybackSections = vhs.playbackSections
+	}
 }

--- a/video.go
+++ b/video.go
@@ -47,15 +47,23 @@ type VideoOutputs struct {
 	Frames string
 }
 
+// PlaybackSection represents a contiguous range of frames with a specific
+// playback speed.
+type PlaybackSection struct {
+	StartFrame int
+	Speed      float64
+}
+
 // VideoOptions is the set of options for converting frames to a GIF.
 type VideoOptions struct {
-	Framerate     int
-	PlaybackSpeed float64
-	Input         string
-	MaxColors     int
-	Output        VideoOutputs
-	StartingFrame int
-	Style         *StyleOptions
+	Framerate        int
+	PlaybackSpeed    float64
+	PlaybackSections []PlaybackSection
+	Input            string
+	MaxColors        int
+	Output           VideoOutputs
+	StartingFrame    int
+	Style            *StyleOptions
 }
 
 const (


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

## Summary
Fixes https://github.com/charmbracelet/vhs/discussions/685 & https://github.com/charmbracelet/vhs/issues/759

Adds new playback speed control feature to VHS, allowing users to vary playback speed at different points in their recordings using the `Playback@<speed>` command. The <speed> value can be either an integer or float with 1 decimal place.

This enables speeding through setup sections while slowing down for important demonstrations, providing more control over the final output than the global `Set PlaybackSpeed` setting(which defines a single speed for the full GIF). Its effectively a way to set up multiple playback speeds as part of the tape file or commands being run.

> To demonstrate this, I used one of [my timer packages](https://github.com/0xjuanma/helm) which makes it very easy to see the playback speed. 

Output GIF:
>TL;DR: 
> Stage 1 runs at 3x speed, 
> Stage 2 runs at 1x speed, 
> Stage 3 runs at 1x speed(for 10sec) then switches to 3x, 
> finally Stage 4 runs at 1x speed again.

![helm-demo3](https://github.com/user-attachments/assets/b1601035-5909-4e2f-893b-f58c792aadb9)

Here is the `demo.tape` used to generate the GIF above:

```
Output helm-demo.gif
Set FontSize 14
Set Width 800
Set Height 500
Set Theme "Darkside"

# Launch Helm(Note: helm is my timer TUI package)
Playback@1
Type "helm"
Enter
Sleep 1s

# Navigate down to show other options
Down
Sleep 500ms
Down
Sleep 500ms

# Pause on current selection
Sleep 500ms

# Select Demo timer
Enter
Sleep 1s

# Start stage(1)
Sleep 1s
Space

# Playback [Stage 1] at 3x speed
Playback@3.0
Sleep 50s

# Pause
Playback@1.0
Space
Sleep 1s

# Skip to next stage(2)
Type "n"
Sleep 1s

# Start [Stage 2] at 1x speed
Space
Playback@1.0
Sleep 30s

# Pause
Space
Sleep 1s

# Start [Stage 3] at 1x speed for 10sec
Type "n"
Space
Sleep 10s


# Update [Stage 3] Playback to 3x speed
Playback@3.0
Sleep 30s

Playback@1.0
# Pause
Space
Sleep 1s

# Skip to next [Stage 4] at 1x speed
Type "n"
Sleep 1s
Space
Sleep 20s

# End
Type "q"
Sleep 1s
```

## Updates
- Added `Playback@<speed>` command with `@` syntax for section-based speed control(follows similar patterns a Type@Xms)
- Implemented per-section playback speed rendering with FFmpeg filter chain
- Added tests coverage for lexer, parser, and command execution
- Documented playback command usage and added syntax highlighting