### PR TITLE
fix: Padding is ignored for `Output frames/`

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 
 	"github.com/charmbracelet/vhs/lexer"
 	"github.com/charmbracelet/vhs/parser"
@@ -116,11 +115,6 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 
 	// Clean up temporary files at the end.
 	defer func() {
-		if v.Options.Video.Output.Frames != "" {
-			// Move the frames to the output directory.
-			_ = os.Rename(v.Options.Video.Input, v.Options.Video.Output.Frames)
-		}
-
 		_ = v.Cleanup()
 	}()
 

--- a/vhs.go
+++ b/vhs.go
@@ -232,6 +232,7 @@ func (vhs *VHS) Render() error {
 	cmds = append(cmds, MakeMP4(vhs.Options.Video))
 	cmds = append(cmds, MakeWebM(vhs.Options.Video))
 	cmds = append(cmds, MakeScreenshots(vhs.Options.Screenshot)...)
+	cmds = append(cmds, MakeFrames(vhs.Options.Video, vhs.totalFrames)...)
 
 	for _, cmd := range cmds {
 		if cmd == nil {


### PR DESCRIPTION
Fixes #258

## Changes
- Add `MakeFrames` function to apply styling (padding, window bar, margins, border radius) to frame output
- Remove raw frame rename/move logic that bypassed styling
- Integrate frame processing into render pipeline alongside GIF/MP4/WebM generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)