### PR TITLE
fix: empty gif after ffmpeg error "Number of frames to loop is not set"

### DIFF
--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -115,7 +115,7 @@ func (fb *FilterComplexBuilder) WithWindowBar(barStream int) *FilterComplexBuild
 		_, _ = fmt.Fprintf(
 			fb.filterComplex,
 			`
-			[%d]loop=-1[loopbar];
+			[%d]loop=-1:1:0[loopbar];
 			[loopbar][%s]overlay=0:%d[withbar]
 			`,
 			barStream,
@@ -136,7 +136,7 @@ func (fb *FilterComplexBuilder) WithBorderRadius(cornerMarkStream int) *FilterCo
 		_, _ = fmt.Fprintf(
 			fb.filterComplex,
 			`
-			[%d]loop=-1[loopmask];
+			[%d]loop=-1:1:0[loopmask];
 			[%s][loopmask]alphamerge[rounded]
 			`,
 			cornerMarkStream,


### PR DESCRIPTION
Fixes #581

## Changes
- Add frame count parameter (`:1:0`) to ffmpeg loop filter for window bar and border radius mask
- Required for FFmpeg 7.0+ which requires the `size` parameter when using infinite loop

The loop filter syntax is `loop=loop_count:size:start`. The bar and mask are single-frame PNG images, so `size=1` with `start=0` is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)