### PR TITLE
chore: change .tape linguist from Elixir to Caddyfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,6 @@
 **/*.mp4 filter=lfs diff=lfs merge=lfs -text
 **/*.webm filter=lfs diff=lfs merge=lfs -text
 **/*.png filter=lfs diff=lfs merge=lfs -text
-*.tape linguist-language=elixir
+*.tape linguist-language=Caddyfile
 themes*.json linguist-generated
 THEMES.md linguist-generated


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

Thank you for creating such a great tool! It was very helpful when I recently created a [README demo for my project](https://github.com/mpyw/suve).

## Changes
Change linguist-language for `.tape` files from `elixir` to `Caddyfile`.

## Motivation
Caddyfile syntax highlighting is more stable for VHS tape files. Elixir highlighting can sometimes break (e.g., when strings or atoms aren't properly balanced), causing the rest of the file to render incorrectly. Caddyfile uses a simpler directive-based syntax that matches tape file structure better.

## Before / After

```elixir
Output examples/meta.webm
Output examples/meta.mp4

Set Width 1920
Set Height 1080
Set FontSize 32
Set Framerate 30
Set Theme { "brightGreen": "#00D787", "brightYellow": "#FE5F86", "yellow": "#FFFFFF", "brightBlue": "#875FFF" }

Hide
Type "cp examples/welcome.tape cassette.tape && clear" Enter
Show

Type "vhs < cassette.tape" Sleep 0.5 Enter

Sleep 30s

Hide
Type "rm cassette.tape" Enter
```

↓

```caddyfile
Output examples/meta.webm
Output examples/meta.mp4

Set Width 1920
Set Height 1080
Set FontSize 32
Set Framerate 30
Set Theme { "brightGreen": "#00D787", "brightYellow": "#FE5F86", "yellow": "#FFFFFF", "brightBlue": "#875FFF" }

Hide
Type "cp examples/welcome.tape cassette.tape && clear" Enter
Show

Type "vhs < cassette.tape" Sleep 0.5 Enter

Sleep 30s

Hide
Type "rm cassette.tape" Enter
```