### PR TITLE
fix: use viewportY offset in Buffer() to read visible viewport

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -67,7 +67,7 @@ func (v *VHS) SaveOutput() error {
 // Buffer returns the current buffer.
 func (v *VHS) Buffer() ([]string, error) {
 	// Get the current buffer.
-	buf, err := v.Page.Eval("() => Array(term.rows).fill(0).map((e, i) => term.buffer.active.getLine(i).translateToString().trimEnd())")
+	buf, err := v.Page.Eval("() => { const s = term.buffer.active.viewportY; return Array(term.rows).fill(0).map((e, i) => term.buffer.active.getLine(s + i).translateToString().trimEnd()); }")
 	if err != nil {
 		return nil, fmt.Errorf("read buffer: %w", err)
 	}


### PR DESCRIPTION
## Summary

`Buffer()` reads lines starting from index 0 of the scrollback buffer instead of the visible viewport. This causes `Wait+Screen` (and `SaveOutput`) to match against lines that have already scrolled off-screen.

The fix adds `viewportY` as the starting offset, consistent with how `CurrentLine()` already works in the same file.

## Changes

One-line change in `testing.go`:

```diff
-buf, err := v.Page.Eval("() => Array(term.rows).fill(0).map((e, i) => term.buffer.active.getLine(i).translateToString().trimEnd())")
+buf, err := v.Page.Eval("() => { const s = term.buffer.active.viewportY; return Array(term.rows).fill(0).map((e, i) => term.buffer.active.getLine(s + i).translateToString().trimEnd()); }")
```

## Reproduction

This tape fails on the current `main` but passes with this fix:

```
Output "/tmp/test.gif"
Set Height 300
Type "seq 10"
Enter
Sleep 1s
Wait+Screen /9/
Type "echo foo"
Enter
Sleep 1s
```

Stock VHS reports: `timeout waiting for "Screen 9" to match 9; last value was: > seq 10 1 2 3 4 5` — it's reading from the top of the scrollback instead of the visible viewport.

## Test plan

- [x] `go test ./...` passes
- [x] Reproduction tape passes with patched binary
- [x] Verified `CurrentLine()` already uses `viewportY` (consistent approach)

Fixes #659