### PR TITLE
docs: fix typo in style comment

### DIFF
--- a/style.go
+++ b/style.go
@@ -37,7 +37,7 @@ const (
 	defaultWidth         = 1200
 )
 
-// Styles for syntax highlightin.
+// Styles for syntax highlighting.
 var (
 	CommandStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
 	FaintStyle      = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "242", Dark: "238"})


### PR DESCRIPTION
## Summary

Fix a typo in the syntax highlighting style comment.

## Related issue

N/A. This is a trivial comment-only fix.

## Guideline alignment

No `CONTRIBUTING.md` or pull request template was present in the repository root or `.github` directory when this PR was prepared.

## Validation/testing

Not run. This is a comment-only change.
