### PR TITLE
fix: kill ttyd process on early exit from Evaluate

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -42,7 +42,12 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 	if err := v.Start(); err != nil {
 		return []error{err}
 	}
-	defer func() { _ = v.close() }()
+	defer func() {
+		_ = v.close()
+		if v.tty != nil && v.tty.Process != nil {
+			_ = v.tty.Process.Kill()
+		}
+	}()
 
 	// Let's wait until we can access the window.term variable.
 	//

--- a/vhs.go
+++ b/vhs.go
@@ -140,11 +140,14 @@ func (vhs *VHS) Start() error {
 	enableNoSandbox := os.Getenv("VHS_NO_SANDBOX") != ""
 	u, err := launcher.New().Leakless(false).Bin(path).NoSandbox(enableNoSandbox).Launch()
 	if err != nil {
+		_ = vhs.tty.Process.Kill()
 		return fmt.Errorf("could not launch browser: %w", err)
 	}
 	browser := rod.New().ControlURL(u).MustConnect()
 	page, err := browser.Page(proto.TargetCreateTarget{URL: fmt.Sprintf("http://localhost:%d", port)})
 	if err != nil {
+		browser.MustClose()
+		_ = vhs.tty.Process.Kill()
 		return fmt.Errorf("could not open ttyd: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #738

## Summary

`ttyd` processes are left running after VHS exits when `Evaluate()` returns early (before `Record()`/`teardown()` are reached).

The deferred cleanup at `evaluator.go:45` only calls `v.close()`, which is set to `vhs.browser.Close` — it never kills the `ttyd` process. The `terminate()` method that properly kills both browser and ttyd is only called via `teardown()`, which is only reachable after `Record()` starts.

**Affected code paths** (all between `Start()` and `Record()`):
- `Page.Wait` fails (line 50-53)
- A `SET` command fails (line 59-63)
- Video dimensions too small (line 78-91)
- A `Hide` block command fails (line 106-109)

Additionally, `Start()` itself didn't clean up ttyd if browser launch or page creation failed after ttyd was already started.

## Fix

- **`evaluator.go`**: The deferred cleanup now also kills the ttyd process, so every early-return path is covered.
- **`vhs.go`**: `Start()` now kills ttyd if subsequent browser/page setup fails, preventing orphaned processes even on initialization errors.

## Test plan

- [x] `go build ./...` passes
- [x] Run `vhs` with a tape that triggers an early exit (e.g., invalid SET command), then verify no orphaned `ttyd` processes remain (`ps aux | grep ttyd`)
- [x] Run `vhs` normally and verify recordings still work correctly