### PR TITLE
feat: Home and End keys support

### DIFF
--- a/command.go
+++ b/command.go
@@ -54,6 +54,8 @@ var CommandFuncs = map[parser.CommandType]CommandFunc{
 	token.PAGE_DOWN:   ExecuteKey(input.PageDown),
 	token.SCROLL_UP:   ExecuteScroll(-1),
 	token.SCROLL_DOWN: ExecuteScroll(1),
+	token.HOME:        ExecuteKey(input.Home),
+	token.END:         ExecuteKey(input.End),
 	token.HIDE:        ExecuteHide,
 	token.REQUIRE:     ExecuteRequire,
 	token.SHOW:        ExecuteShow,
@@ -237,6 +239,10 @@ func ExecuteCtrl(c parser.Command, v *VHS) error {
 			inputKey = &input.ArrowUp
 		case "Down":
 			inputKey = &input.ArrowDown
+		case "Home":
+			inputKey = &input.Home
+		case "End":
+			inputKey = &input.End
 		default:
 			r := rune(key[0])
 			if k, ok := keymap[r]; ok {

--- a/command_test.go
+++ b/command_test.go
@@ -13,7 +13,7 @@ func TestCommand(t *testing.T) {
 		t.Errorf("Expected %d commands, got %d", numberOfCommands, len(parser.CommandTypes))
 	}
 
-	const numberOfCommandFuncs = 31
+	const numberOfCommandFuncs = 33
 	if len(CommandFuncs) != numberOfCommandFuncs {
 		t.Errorf("Expected %d commands, got %d", numberOfCommandFuncs, len(CommandFuncs))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -331,6 +331,8 @@ func (p *Parser) parseCtrl() Command {
 			peek.Type == token.RIGHT,
 			peek.Type == token.UP,
 			peek.Type == token.DOWN,
+			peek.Type == token.HOME,
+			peek.Type == token.END,
 			peek.Type == token.STRING && len(peek.Literal) == 1:
 			args = append(args, peek.Literal)
 		default:


### PR DESCRIPTION
Wire up Home and End keys in CommandFuncs for standalone use, add them as valid arguments in Ctrl/modifier key combinations, and update the ExecuteCtrl handler to map them to the correct input keys.

I wanted to use these keys for generating a GIF, and they seem to work fine so I thought I'd open a PR.

See #603.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
