### PR TITLE
fix: support absolute paths in Output and Screenshot commands

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -417,23 +417,23 @@ func (p *Parser) parseKeypress(ct token.Type) Command {
 func (p *Parser) parseOutput() Command {
 	cmd := Command{Type: token.OUTPUT}
 
-	if p.peek.Type != token.STRING {
+	path, ok := p.parsePathArgument()
+	if !ok {
 		p.errors = append(p.errors, NewError(p.cur, "Expected file path after output"))
 		return cmd
 	}
 
-	ext := filepath.Ext(p.peek.Literal)
+	ext := filepath.Ext(path)
 	if ext != "" {
 		cmd.Options = ext
 	} else {
 		cmd.Options = ".png"
-		if !strings.HasSuffix(p.peek.Literal, "/") {
-			p.errors = append(p.errors, NewError(p.peek, "Expected folder with trailing slash"))
+		if !strings.HasSuffix(path, "/") {
+			p.errors = append(p.errors, NewError(p.cur, "Expected folder with trailing slash"))
 		}
 	}
 
-	cmd.Args = p.peek.Literal
-	p.nextToken()
+	cmd.Args = path
 	return cmd
 }
 
@@ -756,26 +756,44 @@ func (p *Parser) parseSource() []Command {
 func (p *Parser) parseScreenshot() Command {
 	cmd := Command{Type: token.SCREENSHOT}
 
-	if p.peek.Type != token.STRING {
+	path, ok := p.parsePathArgument()
+	if !ok {
 		p.errors = append(p.errors, NewError(p.cur, "Expected path after Screenshot"))
 		p.nextToken()
 		return cmd
 	}
 
-	path := p.peek.Literal
-
 	// Check if path has .png extension
 	ext := filepath.Ext(path)
 	if ext != ".png" {
-		p.errors = append(p.errors, NewError(p.peek, "Expected file with .png extension"))
-		p.nextToken()
+		p.errors = append(p.errors, NewError(p.cur, "Expected file with .png extension"))
 		return cmd
 	}
 
 	cmd.Args = path
-	p.nextToken()
 
 	return cmd
+}
+
+// parsePathArgument parses either a regular string path or an absolute path
+// tokenized as REGEX followed by an optional STRING suffix.
+func (p *Parser) parsePathArgument() (string, bool) {
+	switch p.peek.Type {
+	case token.STRING:
+		path := p.peek.Literal
+		p.nextToken()
+		return path, true
+	case token.REGEX:
+		path := "/" + p.peek.Literal + "/"
+		p.nextToken()
+		if p.peek.Type == token.STRING {
+			path += p.peek.Literal
+			p.nextToken()
+		}
+		return path, true
+	default:
+		return "", false
+	}
 }
 
 // Errors returns any errors that occurred during parsing.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -229,6 +229,54 @@ func TestParseTapeFile(t *testing.T) {
 	}
 }
 
+func TestParseAbsolutePaths(t *testing.T) {
+	input := `
+Output /tmp/demo.gif
+Output /tmp/demo.mp4
+Output /home/user/recordings/demo.webm
+Output /frames/
+Output examples/out.gif
+Output frames/
+Screenshot /tmp/screenshot.png
+Screenshot examples/screenshot.png`
+
+	expected := []Command{
+		{Type: token.OUTPUT, Options: ".gif", Args: "/tmp/demo.gif"},
+		{Type: token.OUTPUT, Options: ".mp4", Args: "/tmp/demo.mp4"},
+		{Type: token.OUTPUT, Options: ".webm", Args: "/home/user/recordings/demo.webm"},
+		{Type: token.OUTPUT, Options: ".png", Args: "/frames/"},
+		{Type: token.OUTPUT, Options: ".gif", Args: "examples/out.gif"},
+		{Type: token.OUTPUT, Options: ".png", Args: "frames/"},
+		{Type: token.SCREENSHOT, Args: "/tmp/screenshot.png"},
+		{Type: token.SCREENSHOT, Args: "examples/screenshot.png"},
+	}
+
+	l := lexer.New(input)
+	p := New(l)
+
+	cmds := p.Parse()
+
+	if len(p.Errors()) > 0 {
+		t.Fatalf("Expected no parser errors, got %v", p.Errors())
+	}
+
+	if len(cmds) != len(expected) {
+		t.Fatalf("Expected %d commands, got %d", len(expected), len(cmds))
+	}
+
+	for i, cmd := range cmds {
+		if cmd.Type != expected[i].Type {
+			t.Errorf("Expected command %d to be %s, got %s", i, expected[i].Type, cmd.Type)
+		}
+		if cmd.Args != expected[i].Args {
+			t.Errorf("Expected command %d to have args %s, got %s", i, expected[i].Args, cmd.Args)
+		}
+		if cmd.Options != expected[i].Options {
+			t.Errorf("Expected command %d to have options %s, got %s", i, expected[i].Options, cmd.Options)
+		}
+	}
+}
+
 func TestParseCtrl(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

`Output /tmp/demo.gif` fails with parser errors because the lexer treats `/` as a regex delimiter. The path `/tmp/demo.gif` tokenizes as `REGEX("tmp")` + `STRING("demo.gif")` instead of a single path token, and `parseOutput()` rejects the unexpected REGEX.

This also breaks the template that `vhs new` generates, which uses an absolute Output path.

Fixes #741

## Root Cause

In `lexer/lexer.go`, `case '/'` always creates a REGEX token via `readRegex('/')`. The parser expects STRING after Output but sees REGEX, producing: "Expected file path after output."

The fix is in the parser, not the lexer. The `/` character is genuinely ambiguous (regex vs path), but the parser knows the context: after `Output`/`Screenshot`, a path is expected. After `Wait`, a regex is expected.

## Changes

Added `parsePathArgument()` in `parser/parser.go` that accepts both STRING tokens (relative paths, existing behavior) and REGEX + STRING sequences (absolute paths like `/tmp/demo.gif`). Both `parseOutput()` and `parseScreenshot()` use this shared helper.

## Testing

Added `TestParseAbsolutePaths` covering:
- `Output /tmp/demo.gif` (absolute GIF)
- `Output /tmp/demo.mp4` (absolute MP4)
- `Output /home/user/recordings/demo.webm` (deep absolute path)
- `Output /frames/` (absolute directory output)
- `Output examples/out.gif` (relative path, unchanged)
- `Output frames/` (relative directory, unchanged)
- `Screenshot /tmp/screenshot.png` (absolute screenshot)
- `Screenshot examples/screenshot.png` (relative screenshot, unchanged)

All 51 existing tests pass. `go vet` and `gofumpt` clean.

### Before

```
$ vhs new test.tape && vhs test.tape

 60 │ Output /tmp/test.gif
      ^^^^^^ Expected file path after output
 60 │ Output /tmp/test.gif
             ^^^ Invalid command: tmp

parser: 3 error(s)
```

### After

```
$ vhs new test.tape && vhs test.tape
Creating /tmp/test.gif...
```


Note: This contribution was developed with AI assist w/ Codex.

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)