### PR TITLE
fix: apply styling to Output Frames

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 
 	"github.com/charmbracelet/vhs/lexer"
 	"github.com/charmbracelet/vhs/parser"
@@ -116,11 +115,6 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 
 	// Clean up temporary files at the end.
 	defer func() {
-		if v.Options.Video.Output.Frames != "" {
-			// Move the frames to the output directory.
-			_ = os.Rename(v.Options.Video.Input, v.Options.Video.Output.Frames)
-		}
-
 		_ = v.Cleanup()
 	}()
 

--- a/vhs.go
+++ b/vhs.go
@@ -232,6 +232,7 @@ func (vhs *VHS) Render() error {
 	cmds = append(cmds, MakeMP4(vhs.Options.Video))
 	cmds = append(cmds, MakeWebM(vhs.Options.Video))
 	cmds = append(cmds, MakeScreenshots(vhs.Options.Screenshot)...)
+	cmds = append(cmds, MakeFrames(vhs.Options.Video, vhs.totalFrames)...)
 
 	for _, cmd := range cmds {
 		if cmd == nil {

--- a/video.go
+++ b/video.go
@@ -152,6 +152,58 @@ func buildFFopts(opts VideoOptions, targetFile string) []string {
 	return args
 }
 
+// MakeFrames processes each raw frame through ffmpeg to apply styling (padding,
+// window bar, border radius, margin) and writes the styled frames to the output
+// directory.
+func MakeFrames(opts VideoOptions, totalFrames int) []*exec.Cmd {
+	if opts.Output.Frames == "" {
+		return nil
+	}
+
+	log.Println(GrayStyle.Render("Creating " + opts.Output.Frames + "..."))
+	ensureDir(filepath.Join(opts.Output.Frames, "frame.png"))
+
+	var cmds []*exec.Cmd
+	for i := 0; i < totalFrames; i++ {
+		frameNum := opts.StartingFrame + i
+		textStream := filepath.Join(opts.Input, fmt.Sprintf(textFrameFormat, frameNum))
+		cursorStream := filepath.Join(opts.Input, fmt.Sprintf(cursorFrameFormat, frameNum))
+
+		if _, err := os.Stat(textStream); err != nil {
+			continue
+		}
+
+		targetFile := filepath.Join(opts.Output.Frames, fmt.Sprintf("frame-%05d.png", i+1))
+
+		streamCounter := 2
+		streamBuilder := NewStreamBuilder(streamCounter, opts.Input, opts.Style)
+		streamBuilder.args = append(streamBuilder.args,
+			"-y",
+			"-i", textStream,
+			"-i", cursorStream,
+		)
+
+		streamBuilder = streamBuilder.
+			WithMargin().
+			WithBar().
+			WithCorner()
+
+		filterBuilder := NewScreenshotFilterComplexBuilder(opts.Style).
+			WithWindowBar(streamBuilder.barStream).
+			WithBorderRadius(streamBuilder.cornerStream).
+			WithMarginFill(streamBuilder.marginStream)
+
+		var args []string
+		args = append(args, streamBuilder.Build()...)
+		args = append(args, filterBuilder.Build()...)
+		args = append(args, targetFile)
+
+		cmds = append(cmds, exec.Command("ffmpeg", args...)) //nolint:gosec
+	}
+
+	return cmds
+}
+
 // MakeGIF takes a list of images (as frames) and converts them to a GIF.
 func MakeGIF(opts VideoOptions) *exec.Cmd {
 	return makeMedia(opts, opts.Output.GIF)


### PR DESCRIPTION
`Output Frames` previously bypassed the ffmpeg styling pipeline by directly renaming the raw captured frames directory to the output path. This meant frames lacked padding, window bar, border radius, and margin styling that GIF/MP4/WebM outputs received.

This processes each frame through ffmpeg using the same screenshot filter pipeline (`NewScreenshotFilterComplexBuilder` + `StreamBuilder`) so all output formats receive consistent styling.

**Before:** `Output frames/` produces raw terminal canvas screenshots with no styling applied.

**After:** `Output frames/` produces styled frames with padding, window bar, border radius, and margin — matching GIF/MP4/WebM output.

Fixes #258

**Validation:**
- `go build ./...` passes
- `go test ./...` passes (all packages)
- `go vet ./...` clean

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).