### PR TITLE
fix: centralize ttdy host

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -16,6 +16,8 @@ import (
 	"os/exec"
 )
 
+const ttyHost = "127.0.0.1"
+
 // randomPort returns a random port number that is not in use.
 func randomPort() int {
 	addr, _ := net.Listen("tcp", ":0") //nolint:gosec,noctx
@@ -27,7 +29,7 @@ func randomPort() int {
 func buildTtyCmd(port int, shell Shell) *exec.Cmd {
 	args := []string{ //nolint:prealloc
 		fmt.Sprintf("--port=%d", port),
-		"--interface", "127.0.0.1",
+		"--interface", ttyHost,
 		"-t", "rendererType=canvas",
 		"-t", "disableResizeOverlay=true",
 		"-t", "enableSixel=true",

--- a/vhs.go
+++ b/vhs.go
@@ -143,7 +143,7 @@ func (vhs *VHS) Start() error {
 		return fmt.Errorf("could not launch browser: %w", err)
 	}
 	browser := rod.New().ControlURL(u).MustConnect()
-	page, err := browser.Page(proto.TargetCreateTarget{URL: fmt.Sprintf("http://localhost:%d", port)})
+	page, err := browser.Page(proto.TargetCreateTarget{URL: ttyURL(port)})
 	if err != nil {
 		return fmt.Errorf("could not open ttyd: %w", err)
 	}
@@ -153,6 +153,10 @@ func (vhs *VHS) Start() error {
 	vhs.close = vhs.browser.Close
 	vhs.started = true
 	return nil
+}
+
+func ttyURL(port int) string {
+	return fmt.Sprintf("http://%s:%d", ttyHost, port)
 }
 
 // Setup sets up the VHS instance and performs the necessary actions to reflect

--- a/vhs_test.go
+++ b/vhs_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestTtyHostMatchesBrowserURL(t *testing.T) {
+	const port = 19760
+
+	cmd := buildTtyCmd(port, Shell{Command: []string{"sh"}})
+	iface := ""
+	for i, arg := range cmd.Args {
+		if arg == "--interface" && i+1 < len(cmd.Args) {
+			iface = cmd.Args[i+1]
+			break
+		}
+	}
+
+	if iface != ttyHost {
+		t.Fatalf("expected ttyd to bind to %q, got %q", ttyHost, iface)
+	}
+
+	wantURL := "http://" + iface + ":19760"
+	if gotURL := ttyURL(port); gotURL != wantURL {
+		t.Fatalf("expected browser URL %q, got %q", wantURL, gotURL)
+	}
+}


### PR DESCRIPTION
- ttyd binds to 127.0.0.1 but vhs.go was opening Chrome at http://localhost:<port>. This does not fail on all machines, but may fail when Chrome chooses IPv6 first.
- This fix centralizes the ttdy host in `ttyHost`, uses it for both the ttyd --interface and the browser URL, and adds `vhs_test.go` to ensure they stay aligned.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] Bug fix, not applicable. ~I have created a discussion that was approved by a maintainer (for new features).~

## How to check whether your machine is susceptible to the bug

Start ttyd the same way VHS does, bound to IPv4 loopback only:

```sh
ttyd --port=19760 --interface 127.0.0.1 --once --writable "$SHELL"
```

In another terminal, test IPv4 and IPv6 localhost separately:

```sh
curl -4 -I http://localhost:19760
curl -6 -I http://localhost:19760
curl -g -I 'http://[::1]:19760'
```

A machine is likely affected when IPv4 works but IPv6 fails:

```sh
curl -4 -I http://localhost:19760
# HTTP/1.1 200 OK

curl -6 -I http://localhost:19760
# curl: (7) Failed to connect to localhost port 19760

curl -g -I 'http://[::1]:19760'
# curl: (7) Failed to connect to ::1 port 19760
```

This can combine badly if `localhost` resolves to `::1` before `127.0.0.1`:

```sh
dscacheutil -q host -a name localhost
```

If `::1` appears before `127.0.0.1`, Chrome may try IPv6 first when VHS opens `http://localhost:<port>`, while ttyd is only listening on `127.0.0.1`.