### PR TITLE
fix: allow numeric output filenames

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -417,24 +417,40 @@ func (p *Parser) parseKeypress(ct token.Type) Command {
 func (p *Parser) parseOutput() Command {
 	cmd := Command{Type: token.OUTPUT}
 
-	if p.peek.Type != token.STRING {
+	if p.peek.Type != token.STRING && p.peek.Type != token.NUMBER {
 		p.errors = append(p.errors, NewError(p.cur, "Expected file path after output"))
 		return cmd
 	}
 
-	ext := filepath.Ext(p.peek.Literal)
+	path := p.parseOutputPath()
+	ext := filepath.Ext(path)
 	if ext != "" {
 		cmd.Options = ext
 	} else {
 		cmd.Options = ".png"
-		if !strings.HasSuffix(p.peek.Literal, "/") {
-			p.errors = append(p.errors, NewError(p.peek, "Expected folder with trailing slash"))
+		if !strings.HasSuffix(path, "/") {
+			p.errors = append(p.errors, NewError(p.cur, "Expected folder with trailing slash"))
 		}
 	}
 
-	cmd.Args = p.peek.Literal
-	p.nextToken()
+	cmd.Args = path
 	return cmd
+}
+
+func (p *Parser) parseOutputPath() string {
+	p.nextToken()
+	path := p.cur.Literal
+
+	for (p.peek.Type == token.STRING || p.peek.Type == token.NUMBER) && isAdjacentToken(p.cur, p.peek) {
+		p.nextToken()
+		path += p.cur.Literal
+	}
+
+	return path
+}
+
+func isAdjacentToken(left, right token.Token) bool {
+	return left.Line == right.Line && left.Column+len(left.Literal) == right.Column
 }
 
 // parseSet parses a set command.

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -117,6 +117,31 @@ Sleep Bar`
 	}
 }
 
+func TestParseOutputNumericFilename(t *testing.T) {
+	l := lexer.New("Output 1.gif")
+	p := New(l)
+
+	cmds := p.Parse()
+
+	if len(p.errors) != 0 {
+		t.Fatalf("Expected no errors, got %v", p.errors)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("Expected 1 command, got %d", len(cmds))
+	}
+
+	cmd := cmds[0]
+	if cmd.Type != token.OUTPUT {
+		t.Fatalf("Expected command type %s, got %s", token.OUTPUT, cmd.Type)
+	}
+	if cmd.Options != ".gif" {
+		t.Fatalf("Expected output extension %q, got %q", ".gif", cmd.Options)
+	}
+	if cmd.Args != "1.gif" {
+		t.Fatalf("Expected output path %q, got %q", "1.gif", cmd.Args)
+	}
+}
+
 func TestParseTapeFile(t *testing.T) {
 	input, err := os.ReadFile("../examples/fixtures/all.tape")
 	if err != nil {


### PR DESCRIPTION
Fixes #62.

## Summary
- Allow `Output` paths that start with numeric lexer fragments, such as `1.gif`.
- Recombine adjacent numeric/string path tokens before determining the output extension.
- Add parser regression coverage for numeric output filenames.

## Tests
- Red before fix: `go test ./parser -run TestParseOutputNumericFilename -count=1` failed with `Expected file path after output` and invalid `1.` / `gif` commands
- `go test ./parser -run TestParseOutputNumericFilename -count=1`
- `go test ./parser -count=1`
- `go test ./...`
- `git diff --check`
