### PR TITLE
feat: rows/cols for axises

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,34 @@ Set Height 1000
   <img width="300" alt="Example of changing the height of the terminal" src="https://stuff.charm.sh/vhs/examples/height.gif">
 </picture>
 
+#### Set Columns
+
+Set the width of the terminal in columns (character cells) with the `Set
+Columns` command. VHS derives the final pixel width from the current font
+settings (`FontSize`, `FontFamily`, `LetterSpacing`) plus `Padding`/`Margin`.
+
+```elixir
+Set Columns 100
+```
+
+`Set Columns` cannot be combined with `Set Width` — use one or the other to
+control the terminal's width. It can be freely combined with `Set Height`
+or `Set Rows` to control height.
+
+#### Set Rows
+
+Set the height of the terminal in rows (character cells) with the `Set Rows`
+command. VHS derives the final pixel height from the current font settings
+(`FontSize`, `FontFamily`, `LineHeight`) plus `Padding`/`Margin`/`WindowBar`.
+
+```elixir
+Set Rows 40
+```
+
+`Set Rows` cannot be combined with `Set Height` — use one or the other to
+control the terminal's height. It can be freely combined with `Set Width`
+or `Set Columns` to control width.
+
 #### Set Letter Spacing
 
 Set the spacing between letters (tracking) with the `Set LetterSpacing`

--- a/command.go
+++ b/command.go
@@ -473,6 +473,8 @@ var Settings = map[string]CommandFunc{
 	"TypingSpeed":   ExecuteSetTypingSpeed,
 	"Width":         ExecuteSetWidth,
 	shellSetting:    ExecuteSetShell,
+	"Rows":          ExecuteSetRows,
+	"Columns":       ExecuteSetColumns,
 	"LoopOffset":    ExecuteLoopOffset,
 	"MarginFill":    ExecuteSetMarginFill,
 	"Margin":        ExecuteSetMargin,
@@ -531,7 +533,11 @@ func ExecuteSetHeight(c parser.Command, v *VHS) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse height: %w", err)
 	}
+	if v.Options.Video.Style.Rows > 0 {
+		return fmt.Errorf("cannot set both Height and Rows")
+	}
 	v.Options.Video.Style.Height = height
+	v.heightExplicit = true
 
 	return nil
 }
@@ -542,7 +548,47 @@ func ExecuteSetWidth(c parser.Command, v *VHS) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse width: %w", err)
 	}
+	if v.Options.Video.Style.Columns > 0 {
+		return fmt.Errorf("cannot set both Width and Columns")
+	}
 	v.Options.Video.Style.Width = width
+	v.widthExplicit = true
+
+	return nil
+}
+
+// ExecuteSetRows applies the number of terminal rows on the vhs, overriding
+// Height once the terminal is set up.
+func ExecuteSetRows(c parser.Command, v *VHS) error {
+	rows, err := strconv.Atoi(c.Args)
+	if err != nil {
+		return fmt.Errorf("failed to parse rows: %w", err)
+	}
+	if rows <= 0 {
+		return fmt.Errorf("rows must be a positive integer")
+	}
+	if v.heightExplicit {
+		return fmt.Errorf("cannot set both Height and Rows")
+	}
+	v.Options.Video.Style.Rows = rows
+
+	return nil
+}
+
+// ExecuteSetColumns applies the number of terminal columns on the vhs,
+// overriding Width once the terminal is set up.
+func ExecuteSetColumns(c parser.Command, v *VHS) error {
+	columns, err := strconv.Atoi(c.Args)
+	if err != nil {
+		return fmt.Errorf("failed to parse columns: %w", err)
+	}
+	if columns <= 0 {
+		return fmt.Errorf("columns must be a positive integer")
+	}
+	if v.widthExplicit {
+		return fmt.Errorf("cannot set both Width and Columns")
+	}
+	v.Options.Video.Style.Columns = columns
 
 	return nil
 }

--- a/command_test.go
+++ b/command_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/vhs/parser"
+	"github.com/charmbracelet/vhs/token"
 )
 
 func TestCommand(t *testing.T) {
@@ -52,6 +53,92 @@ func TestExecuteSetTheme(t *testing.T) {
 		theme, err := getTheme("foobar")
 		requireErr(t, err)
 		requireDefaultTheme(t, theme)
+	})
+}
+
+func TestExecuteSetRowsColumns(t *testing.T) {
+	t.Run("rows", func(t *testing.T) {
+		v := New()
+		err := ExecuteSetRows(parser.Command{Type: token.SET, Options: "Rows", Args: "40"}, &v)
+		requireNoErr(t, err)
+		if v.Options.Video.Style.Rows != 40 {
+			t.Errorf("expected Rows to be 40, got %d", v.Options.Video.Style.Rows)
+		}
+	})
+
+	t.Run("columns", func(t *testing.T) {
+		v := New()
+		err := ExecuteSetColumns(parser.Command{Type: token.SET, Options: "Columns", Args: "100"}, &v)
+		requireNoErr(t, err)
+		if v.Options.Video.Style.Columns != 100 {
+			t.Errorf("expected Columns to be 100, got %d", v.Options.Video.Style.Columns)
+		}
+	})
+
+	t.Run("rows must be positive", func(t *testing.T) {
+		v := New()
+		err := ExecuteSetRows(parser.Command{Type: token.SET, Options: "Rows", Args: "0"}, &v)
+		requireErr(t, err)
+	})
+
+	t.Run("columns must be positive", func(t *testing.T) {
+		v := New()
+		err := ExecuteSetColumns(parser.Command{Type: token.SET, Options: "Columns", Args: "0"}, &v)
+		requireErr(t, err)
+	})
+
+	t.Run("height then rows conflict", func(t *testing.T) {
+		v := New()
+		requireNoErr(t, ExecuteSetHeight(parser.Command{Type: token.SET, Options: "Height", Args: "600"}, &v))
+		err := ExecuteSetRows(parser.Command{Type: token.SET, Options: "Rows", Args: "40"}, &v)
+		requireErr(t, err)
+		if v.Options.Video.Style.Rows != 0 {
+			t.Errorf("expected Rows to remain unset, got %d", v.Options.Video.Style.Rows)
+		}
+	})
+
+	t.Run("rows then height conflict", func(t *testing.T) {
+		v := New()
+		requireNoErr(t, ExecuteSetRows(parser.Command{Type: token.SET, Options: "Rows", Args: "40"}, &v))
+		defaultHeight := v.Options.Video.Style.Height
+		err := ExecuteSetHeight(parser.Command{Type: token.SET, Options: "Height", Args: "700"}, &v)
+		requireErr(t, err)
+		if v.Options.Video.Style.Height != defaultHeight {
+			t.Errorf("expected Height to remain unchanged, got %d", v.Options.Video.Style.Height)
+		}
+	})
+
+	t.Run("width then columns conflict", func(t *testing.T) {
+		v := New()
+		requireNoErr(t, ExecuteSetWidth(parser.Command{Type: token.SET, Options: "Width", Args: "1200"}, &v))
+		err := ExecuteSetColumns(parser.Command{Type: token.SET, Options: "Columns", Args: "100"}, &v)
+		requireErr(t, err)
+		if v.Options.Video.Style.Columns != 0 {
+			t.Errorf("expected Columns to remain unset, got %d", v.Options.Video.Style.Columns)
+		}
+	})
+
+	t.Run("columns then width conflict", func(t *testing.T) {
+		v := New()
+		requireNoErr(t, ExecuteSetColumns(parser.Command{Type: token.SET, Options: "Columns", Args: "100"}, &v))
+		defaultWidth := v.Options.Video.Style.Width
+		err := ExecuteSetWidth(parser.Command{Type: token.SET, Options: "Width", Args: "1300"}, &v)
+		requireErr(t, err)
+		if v.Options.Video.Style.Width != defaultWidth {
+			t.Errorf("expected Width to remain unchanged, got %d", v.Options.Video.Style.Width)
+		}
+	})
+
+	t.Run("width and rows can coexist", func(t *testing.T) {
+		v := New()
+		requireNoErr(t, ExecuteSetWidth(parser.Command{Type: token.SET, Options: "Width", Args: "1200"}, &v))
+		requireNoErr(t, ExecuteSetRows(parser.Command{Type: token.SET, Options: "Rows", Args: "40"}, &v))
+	})
+
+	t.Run("height and columns can coexist", func(t *testing.T) {
+		v := New()
+		requireNoErr(t, ExecuteSetHeight(parser.Command{Type: token.SET, Options: "Height", Args: "600"}, &v))
+		requireNoErr(t, ExecuteSetColumns(parser.Command{Type: token.SET, Options: "Columns", Args: "100"}, &v))
 	})
 }
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -91,7 +91,9 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 	}
 
 	// Setup the terminal session so we can start executing commands.
-	v.Setup()
+	if err := v.Setup(); err != nil {
+		return []error{err}
+	}
 
 	// If the first command (after Settings and Outputs) is a Hide command, we can
 	// begin executing the commands before we start recording to avoid capturing

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -32,6 +32,68 @@ Type "I'm a big teapot"
 Sleep 1s
 ```
 
+### Rows
+
+<img width="600" src="./rows.gif" />
+
+```
+Output examples/settings/rows.gif
+
+Set Width 475
+Set Rows 8
+Set FontSize 32
+
+# Fill the terminal with a line-numbered count. Since it's cleared
+# first, the count fills the frame edge-to-edge with nothing else
+# on screen: exactly 8 lines for 8 rows, no more, no less. The
+# last line skips its trailing newline so the terminal doesn't
+# scroll once more to make room for the next prompt.
+Type "clear; for i in $(seq 1 7); do echo $i; done; printf 8; sleep 5"
+Enter
+
+Sleep 2s
+```
+
+### Columns
+
+<img width="600" src="./columns.gif" />
+
+```
+Output examples/settings/columns.gif
+
+Set Height 400
+Set Columns 30
+Set FontSize 32
+
+# Print a 30-character ruler after clearing. It touches the left
+# and right edges of the frame exactly, with no wrap: 30 columns.
+Type "clear; printf '%030d\n' 0 | tr '0' '#'; sleep 5"
+Enter
+
+Sleep 2s
+```
+
+### Rows and Columns
+
+<img width="600" src="./rows-columns.gif" />
+
+```
+Output examples/settings/rows-columns.gif
+
+Set FontSize 32
+Set Rows 10
+Set Columns 40
+
+# A 40-char ruler as the first line proves the column count, and
+# it plus 9 more numbered lines below it fill the frame exactly
+# top to bottom, proving all 10 rows. The last line skips its
+# trailing newline so the terminal doesn't scroll for a new prompt.
+Type "clear; printf '%040d\n' 0 | tr '0' '#'; for i in $(seq 1 8); do echo $i; done; printf 9; sleep 5"
+Enter
+
+Sleep 2s
+```
+
 ### Font Family
 
 <img width="600" src="./set-font-family.gif" />

--- a/examples/settings/columns.gif
+++ b/examples/settings/columns.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c98b0854ff508a39b320b149011a8a1b68da5a3401c5f1cb6c5ceef41271f63b
+size 45378

--- a/examples/settings/columns.tape
+++ b/examples/settings/columns.tape
@@ -1,0 +1,16 @@
+Output examples/settings/columns.gif
+
+Set Height 400
+Set Columns 30
+Set FontSize 32
+
+# A count from 1 to 30, one digit per column, touches the left and
+# right edges of the frame exactly with no wrap: 30 columns.
+Hide
+Type "clear; echo 123456789012345678901234567890"
+Show
+
+Sleep 1s
+Enter
+
+Sleep 2s

--- a/examples/settings/rows-columns.gif
+++ b/examples/settings/rows-columns.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b3af2510614f13779de30c65e15cbfe2299cbecd814a1e939be3d796e1ff19
+size 114091

--- a/examples/settings/rows-columns.tape
+++ b/examples/settings/rows-columns.tape
@@ -1,0 +1,19 @@
+Output examples/settings/rows-columns.gif
+
+Set FontSize 32
+Set Rows 10
+Set Columns 40
+
+# A count from 1 to 40 as the first line proves the column count,
+# and it plus 9 more numbered lines below it fill the frame exactly
+# top to bottom, proving all 10 rows. The last line skips its
+# trailing newline so the returning prompt lands on the same line
+# instead of scrolling everything up by one.
+Hide
+Type "clear; echo 1234567890123456789012345678901234567890; echo Line 2; echo Line 3; echo Line 4; echo Line 5; echo Line 6; echo Line 7; echo Line 8; echo Line 9; printf 'Line 10'"
+Show
+
+Sleep 1s
+Enter
+
+Sleep 2s

--- a/examples/settings/rows.gif
+++ b/examples/settings/rows.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72544dc67afc8fc3bb3c009c2a2d65c4430db94fcbeaec996d636ee0ab676bf7
+size 67974

--- a/examples/settings/rows.tape
+++ b/examples/settings/rows.tape
@@ -1,0 +1,18 @@
+Output examples/settings/rows.gif
+
+Set Width 475
+Set Rows 8
+Set FontSize 32
+
+# Eight lines of "Line N", filling the frame edge to edge: exactly
+# 8 lines for 8 rows, no more, no less. The last one skips its
+# trailing newline so the returning prompt lands on the same line
+# instead of scrolling everything up by one.
+Hide
+Type "clear; echo Line 1; echo Line 2; echo Line 3; echo Line 4; echo Line 5; echo Line 6; echo Line 7; printf 'Line 8'"
+Show
+
+Sleep 1s
+Enter
+
+Sleep 2s

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/vhs
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -12,6 +12,8 @@ func TestNextToken(t *testing.T) {
 Output examples/out.gif
 Set FontSize 42
 Set Padding 5
+Set Rows 40
+Set Columns 100
 Set CursorBlink false
 Type "echo 'Hello, world!'"
 Enter
@@ -48,6 +50,12 @@ Wait+Screen@1m /foo\\\/bar/`
 		{token.SET, "Set"},
 		{token.PADDING, "Padding"},
 		{token.NUMBER, "5"},
+		{token.SET, "Set"},
+		{token.ROWS, "Rows"},
+		{token.NUMBER, "40"},
+		{token.SET, "Set"},
+		{token.COLUMNS, "Columns"},
+		{token.NUMBER, "100"},
 		{token.SET, "Set"},
 		{token.CURSOR_BLINK, "CursorBlink"},
 		{token.BOOLEAN, "false"},

--- a/main.go
+++ b/main.go
@@ -63,7 +63,11 @@ var (
 			// Set the input to the file contents if a file is given
 			// otherwise, use stdin
 			if len(args) > 0 && args[0] != "-" {
-				in, err = os.Open(args[0])
+				filename := args[0]
+				if !strings.HasSuffix(filename, extension) {
+					filename = filename + extension
+				}
+				in, err = os.Open(filename)
 				if err != nil {
 					return err
 				}

--- a/man.go
+++ b/man.go
@@ -68,6 +68,8 @@ The following is a list of all possible setting commands in VHS:
 * Set %FontFamily% <string>
 * Set %Height% <number>
 * Set %Width% <number>
+* Set %Rows% <number>
+* Set %Columns% <number>
 * Set %LetterSpacing% <float>
 * Set %LineHeight% <float>
 * Set %TypingSpeed% <time>

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -462,6 +462,27 @@ func (st *parseScreenshotTest) run(t *testing.T) {
 	}
 }
 
+func TestParseSetRowsColumns(t *testing.T) {
+	input := `
+Set Rows 40
+Set Columns 100`
+
+	expected := []Command{
+		{Type: token.SET, Options: "Rows", Args: "40"},
+		{Type: token.SET, Options: "Columns", Args: "100"},
+	}
+
+	l := lexer.New(input)
+	p := New(l)
+	actual := p.Parse()
+
+	for i, cmd := range actual {
+		if cmd != expected[i] {
+			t.Errorf("Expected %+v, got %+v", expected[i], cmd)
+		}
+	}
+}
+
 func TestParseScreeenshot(t *testing.T) {
 	t.Run("should return error when screenshot extension is NOT (.png)", func(t *testing.T) {
 		test := &parseScreenshotTest{

--- a/style.go
+++ b/style.go
@@ -60,8 +60,13 @@ var (
 
 // StyleOptions represents the ui options for video and screenshots.
 type StyleOptions struct {
-	Width           int
-	Height          int
+	Width  int
+	Height int
+	// Rows and Columns, when non-zero, take precedence over Height and Width
+	// respectively: the terminal is sized to fit exactly that many rows/columns
+	// of the configured font, and Height/Width are derived from it instead.
+	Rows            int
+	Columns         int
 	Padding         int
 	BackgroundColor string
 	MarginFill      string

--- a/token/token.go
+++ b/token/token.go
@@ -92,6 +92,8 @@ const (
 	PLAYBACK_SPEED  = "PLAYBACK_SPEED"
 	HEIGHT          = "HEIGHT"
 	WIDTH           = "WIDTH"
+	ROWS            = "ROWS"
+	COLUMNS         = "COLUMNS"
 	LETTER_SPACING  = "LETTER_SPACING"
 	LINE_HEIGHT     = "LINE_HEIGHT"
 	TYPING_SPEED    = "TYPING_SPEED"
@@ -159,6 +161,8 @@ var Keywords = map[string]Type{
 	"Padding":       PADDING,
 	"Theme":         THEME,
 	"Width":         WIDTH,
+	"Rows":          ROWS,
+	"Columns":       COLUMNS,
 	"LoopOffset":    LOOP_OFFSET,
 	"WaitTimeout":   WAIT_TIMEOUT,
 	"WaitPattern":   WAIT_PATTERN,
@@ -178,6 +182,7 @@ func IsSetting(t Type) bool {
 	switch t {
 	case SHELL, FONT_FAMILY, FONT_SIZE, LETTER_SPACING, LINE_HEIGHT,
 		FRAMERATE, TYPING_SPEED, THEME, PLAYBACK_SPEED, HEIGHT, WIDTH,
+		ROWS, COLUMNS,
 		PADDING, LOOP_OFFSET, MARGIN_FILL, MARGIN, WINDOW_BAR,
 		WINDOW_BAR_SIZE, BORDER_RADIUS, CURSOR_BLINK, WAIT_TIMEOUT, WAIT_PATTERN:
 		return true

--- a/vhs.go
+++ b/vhs.go
@@ -21,18 +21,20 @@ import (
 
 // VHS is the object that controls the setup.
 type VHS struct {
-	Options      *Options
-	Errors       []error
-	Page         *rod.Page
-	browser      *rod.Browser
-	TextCanvas   *rod.Element
-	CursorCanvas *rod.Element
-	mutex        *sync.Mutex
-	started      bool
-	recording    bool
-	tty          *exec.Cmd
-	totalFrames  int
-	close        func() error
+	Options        *Options
+	Errors         []error
+	Page           *rod.Page
+	browser        *rod.Browser
+	TextCanvas     *rod.Element
+	CursorCanvas   *rod.Element
+	mutex          *sync.Mutex
+	started        bool
+	recording      bool
+	tty            *exec.Cmd
+	totalFrames    int
+	close          func() error
+	widthExplicit  bool
+	heightExplicit bool
 }
 
 // Options is the set of options for the setup.
@@ -158,36 +160,133 @@ func (vhs *VHS) Start(ctx context.Context) error {
 // Setup sets up the VHS instance and performs the necessary actions to reflect
 // the options that are default and set by the user.
 func (vhs *VHS) Setup() {
-	// Set Viewport to the correct size, accounting for the padding that will be
-	// added during the render.
-	padding := vhs.Options.Video.Style.Padding
-	margin := 0
-	if vhs.Options.Video.Style.MarginFill != "" {
-		margin = vhs.Options.Video.Style.Margin
-	}
-	bar := 0
-	if vhs.Options.Video.Style.WindowBar != "" {
-		bar = vhs.Options.Video.Style.WindowBarSize
-	}
-	width := vhs.Options.Video.Style.Width - double(padding) - double(margin)
-	height := vhs.Options.Video.Style.Height - double(padding) - double(margin) - bar
-	vhs.Page = vhs.Page.MustSetViewport(width, height, 0, false)
+	style := vhs.Options.Video.Style
 
 	// Find xterm.js canvases for the text and cursor layer for recording.
+	// These exist as soon as ttyd opens the terminal, so this doesn't need
+	// to wait for the viewport/font to be set below.
 	vhs.TextCanvas, _ = vhs.Page.Element("canvas.xterm-text-layer")
 	vhs.CursorCanvas, _ = vhs.Page.Element("canvas.xterm-cursor-layer")
 
 	// Apply options to the terminal
 	// By this point the setting commands have been executed, so the `opts` struct is up to date.
+	//
+	// This must happen before the viewport is sized below: it determines the
+	// pixel size of a rendered character cell, which the Rows/Columns case
+	// needs in order to compute the viewport, and FontSize/FontFamily/
+	// LetterSpacing/LineHeight all affect it.
 	vhs.Page.MustEval(fmt.Sprintf("() => { term.options = { fontSize: %d, fontFamily: '%s', letterSpacing: %f, lineHeight: %f, theme: %s, cursorBlink: %t } }",
 		vhs.Options.FontSize, vhs.Options.FontFamily, vhs.Options.LetterSpacing,
 		vhs.Options.LineHeight, vhs.Options.Theme.String(), vhs.Options.CursorBlink))
+
+	// Account for the padding, margin, and window bar that will be added
+	// during the render to determine the viewport size.
+	padding := style.Padding
+	margin := 0
+	if style.MarginFill != "" {
+		margin = style.Margin
+	}
+	bar := 0
+	if style.WindowBar != "" {
+		bar = style.WindowBarSize
+	}
+	if style.Rows > 0 || style.Columns > 0 {
+		vhs.resolveRowsColumns(padding, margin, bar)
+	}
+
+	width := style.Width - double(padding) - double(margin)
+	height := style.Height - double(padding) - double(margin) - bar
+	vhs.Page = vhs.Page.MustSetViewport(width, height, 0, false)
 
 	// Fit the terminal into the window
 	vhs.Page.MustEval("term.fit")
 
 	_ = os.RemoveAll(vhs.Options.Video.Input)
 	_ = os.MkdirAll(vhs.Options.Video.Input, 0o750)
+}
+
+const (
+	dimensionProbeAttempts      = 6
+	dimensionCorrectionAttempts = 5
+)
+
+// resolveRowsColumns derives the pixel Width/Height needed to render the
+// requested number of terminal Rows/Columns, overwriting
+// vhs.Options.Video.Style.Width/Height in place. The normal viewport-sizing
+// code that follows this call then behaves exactly as it does for a plain
+// Set Height/Set Width, since by the time it runs, style.Width/style.Height
+// already reflect the resolved grid size.
+//
+// VHS has no native pty (it drives a headless-browser xterm.js instance via
+// ttyd), so there is no Go-side font metrics available. Instead, this probes
+// the live terminal at a candidate pixel size, reads back the resulting
+// term.cols/term.rows (the same public API xterm's own fit addon exposes),
+// and uses that ratio to estimate cell size, then iterates to correct for
+// the integer floor-rounding xterm's fit addon applies internally.
+func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
+	style := vhs.Options.Video.Style
+
+	measure := func(w, h int) (cols, rows int) {
+		vhs.Page = vhs.Page.MustSetViewport(w, h, 0, false)
+		vhs.Page.MustEval("term.fit")
+		dims := vhs.Page.MustEval("() => ({ cols: term.cols, rows: term.rows })")
+		return dims.Get("cols").Int(), dims.Get("rows").Int()
+	}
+
+	probeWidth := style.Width - double(padding) - double(margin)
+	probeHeight := style.Height - double(padding) - double(margin) - bar
+
+	var cellWidth, cellHeight float64
+	for range dimensionProbeAttempts {
+		cols, rows := measure(probeWidth, probeHeight)
+
+		tooSmall := cols <= 0 || rows <= 0 ||
+			(style.Columns > 0 && cols < style.Columns) ||
+			(style.Rows > 0 && rows < style.Rows)
+		if !tooSmall {
+			cellWidth = float64(probeWidth) / float64(cols)
+			cellHeight = float64(probeHeight) / float64(rows)
+			break
+		}
+		probeWidth = double(probeWidth)
+		probeHeight = double(probeHeight)
+	}
+
+	contentWidth := probeWidth
+	contentHeight := probeHeight
+	if style.Columns > 0 {
+		contentWidth = int(math.Round(cellWidth * float64(style.Columns)))
+	}
+	if style.Rows > 0 {
+		contentHeight = int(math.Round(cellHeight * float64(style.Rows)))
+	}
+
+	// xterm's fit addon floors container-size / cell-size, so the estimate
+	// above can be off by a cell. Nudge the content size until the measured
+	// cols/rows exactly match what was requested.
+	for range dimensionCorrectionAttempts {
+		cols, rows := measure(contentWidth, contentHeight)
+
+		converged := true
+		if style.Columns > 0 && cols != style.Columns {
+			contentWidth += int(math.Round(float64(style.Columns-cols) * cellWidth))
+			converged = false
+		}
+		if style.Rows > 0 && rows != style.Rows {
+			contentHeight += int(math.Round(float64(style.Rows-rows) * cellHeight))
+			converged = false
+		}
+		if converged {
+			break
+		}
+	}
+
+	if style.Columns > 0 {
+		style.Width = contentWidth + double(padding) + double(margin)
+	}
+	if style.Rows > 0 {
+		style.Height = contentHeight + double(padding) + double(margin) + bar
+	}
 }
 
 const cleanupWaitTime = 100 * time.Millisecond

--- a/vhs.go
+++ b/vhs.go
@@ -317,13 +317,23 @@ func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) error {
 	}
 
 	if style.Columns > 0 {
-		style.Width = contentWidth + double(padding) + double(margin)
+		style.Width = roundUpToEven(contentWidth + double(padding) + double(margin))
 	}
 	if style.Rows > 0 {
-		style.Height = contentHeight + double(padding) + double(margin) + bar
+		style.Height = roundUpToEven(contentHeight + double(padding) + double(margin) + bar)
 	}
 
 	return nil
+}
+
+// roundUpToEven rounds n up to the nearest even number. MP4 and WebM
+// encoders require even width/height, and the grid-derived dimensions above
+// can land on an odd pixel count.
+func roundUpToEven(n int) int {
+	if n%2 != 0 {
+		return n + 1
+	}
+	return n
 }
 
 // describeGrid names the grid size that was requested, mentioning only the

--- a/vhs.go
+++ b/vhs.go
@@ -159,7 +159,7 @@ func (vhs *VHS) Start(ctx context.Context) error {
 
 // Setup sets up the VHS instance and performs the necessary actions to reflect
 // the options that are default and set by the user.
-func (vhs *VHS) Setup() {
+func (vhs *VHS) Setup() error {
 	style := vhs.Options.Video.Style
 
 	// Find xterm.js canvases for the text and cursor layer for recording.
@@ -191,7 +191,9 @@ func (vhs *VHS) Setup() {
 		bar = style.WindowBarSize
 	}
 	if style.Rows > 0 || style.Columns > 0 {
-		vhs.resolveRowsColumns(padding, margin, bar)
+		if err := vhs.resolveRowsColumns(padding, margin, bar); err != nil {
+			return err
+		}
 	}
 
 	width := style.Width - double(padding) - double(margin)
@@ -203,6 +205,8 @@ func (vhs *VHS) Setup() {
 
 	_ = os.RemoveAll(vhs.Options.Video.Input)
 	_ = os.MkdirAll(vhs.Options.Video.Input, 0o750)
+
+	return nil
 }
 
 const (
@@ -223,7 +227,11 @@ const (
 // term.cols/term.rows (the same public API xterm's own fit addon exposes),
 // and uses that ratio to estimate cell size, then iterates to correct for
 // the integer floor-rounding xterm's fit addon applies internally.
-func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
+//
+// Both loops are bounded, and an error is returned rather than settling for a
+// grid that doesn't match what was asked for: giving up quietly would render
+// the tape at the wrong size, or at 0x0 if the terminal was never measured.
+func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) error {
 	style := vhs.Options.Video.Style
 
 	measure := func(w, h int) (cols, rows int) {
@@ -237,8 +245,11 @@ func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
 	probeHeight := style.Height - double(padding) - double(margin) - bar
 
 	var cellWidth, cellHeight float64
+	var measured bool
+	var lastCols, lastRows int
 	for range dimensionProbeAttempts {
 		cols, rows := measure(probeWidth, probeHeight)
+		lastCols, lastRows = cols, rows
 
 		tooSmall := cols <= 0 || rows <= 0 ||
 			(style.Columns > 0 && cols < style.Columns) ||
@@ -246,10 +257,21 @@ func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
 		if !tooSmall {
 			cellWidth = float64(probeWidth) / float64(cols)
 			cellHeight = float64(probeHeight) / float64(rows)
+			measured = true
 			break
 		}
 		probeWidth = double(probeWidth)
 		probeHeight = double(probeHeight)
+	}
+
+	// Without a successful measurement there is no cell size to scale by, and
+	// continuing would size the viewport to 0x0.
+	if !measured {
+		return fmt.Errorf(
+			"could not fit %s: terminal measured %d columns x %d rows at %dx%d pixels after %d attempts",
+			describeGrid(style.Columns, style.Rows),
+			lastCols, lastRows, probeWidth, probeHeight, dimensionProbeAttempts,
+		)
 	}
 
 	contentWidth := probeWidth
@@ -264,8 +286,10 @@ func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
 	// xterm's fit addon floors container-size / cell-size, so the estimate
 	// above can be off by a cell. Nudge the content size until the measured
 	// cols/rows exactly match what was requested.
+	var corrected bool
 	for range dimensionCorrectionAttempts {
 		cols, rows := measure(contentWidth, contentHeight)
+		lastCols, lastRows = cols, rows
 
 		converged := true
 		if style.Columns > 0 && cols != style.Columns {
@@ -277,8 +301,19 @@ func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
 			converged = false
 		}
 		if converged {
+			corrected = true
 			break
 		}
+	}
+
+	// The grid never settled on the requested size, so recording now would
+	// silently produce a tape with the wrong number of rows/columns.
+	if !corrected {
+		return fmt.Errorf(
+			"could not resolve a viewport for %s: closest match was %d columns x %d rows after %d attempts",
+			describeGrid(style.Columns, style.Rows),
+			lastCols, lastRows, dimensionCorrectionAttempts,
+		)
 	}
 
 	if style.Columns > 0 {
@@ -286,6 +321,21 @@ func (vhs *VHS) resolveRowsColumns(padding, margin, bar int) {
 	}
 	if style.Rows > 0 {
 		style.Height = contentHeight + double(padding) + double(margin) + bar
+	}
+
+	return nil
+}
+
+// describeGrid names the grid size that was requested, mentioning only the
+// dimension(s) the tape actually set.
+func describeGrid(columns, rows int) string {
+	switch {
+	case columns > 0 && rows > 0:
+		return fmt.Sprintf("%d columns x %d rows", columns, rows)
+	case columns > 0:
+		return fmt.Sprintf("%d columns", columns)
+	default:
+		return fmt.Sprintf("%d rows", rows)
 	}
 }
 


### PR DESCRIPTION
Adds `Set Rows`/`Set Columns` commands to size the terminal in character
cells instead of pixels. The pixel size is derived by probing the live
xterm.js terminal's own fit/measurement APIs and iterating to an exact
match, so it stays correct across font/theme changes without depending
on any of xterm.js's private internals.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features). (I got Discord approval, if that counts)
