### PR TITLE
docs: link interactive theme preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ Set Theme "Catppuccin Frappe"
 ```
 
 See the full list by running `vhs themes`, or in [THEMES.md](./THEMES.md).
+For an interactive preview, visit
+[Windows Terminal Themes](https://windowsterminalthemes.dev/).
 
 #### Set Padding
 


### PR DESCRIPTION
## Summary

Add the interactive Windows Terminal Themes preview beside the existing VHS
theme-list references.

Fixes #487.

An earlier attempt in #714 was self-closed by its author without review; this
keeps the issue's requested link and the current README wording narrowly scoped.

## Validation

- confirmed the preview URL returns HTTP 200
- confirmed the local `THEMES.md` reference still resolves
- `git diff --check origin/main...HEAD`

- [x] I have read the contribution guidelines.
- [x] This is an issue-backed documentation fix; no new-feature discussion is required.

Assisted by OpenAI Codex; the change, issue state, target link, and rendered Markdown structure were reviewed and validated by me.
