### PR TITLE
fix(windows): pass explicit working directory to prevent TTYD crash

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // randomPort returns a random port number that is not in use.
@@ -34,6 +35,10 @@ func buildTtyCmd(port int, shell Shell) *exec.Cmd {
 		"-t", "customGlyphs=true",
 		"--once", // will allow one connection and exit
 		"--writable",
+	}
+
+	if runtime.GOOS == "windows" {
+		args = append(args, "-w", ".")
 	}
 
 	args = append(args, shell.Command...)


### PR DESCRIPTION
Fixes #754.

This PR fixes a bug where `vhs` panics and crashes during setup on Windows when using the latest official `ttyd` release (v1.7.7). I encountered this exact issue when running `powershell` tapes.

**The Bug**
When running a tape file on Windows, `vhs` panics because the `ttyd` server instantly crashes in the background, causing `go-rod` to lose its WebSocket connection:

```text
$ vhs .\v3-release.tape
File: .\v3-release.tape
Output .gif demo.gif
Set FontSize 46
Set Width 1200
Set Height 600

panic: write tcp 127.0.0.1:54658->127.0.0.1:54656: use of closed network connection
goroutine 1 [running]:
github.com/go-rod/rod/lib/utils.init.func2({0x7ff668433060?, 0x3b03f87e320?})
        /home/runner/go/pkg/mod/github.com/go-rod/rod@v0.116.2/lib/utils/utils.go:68 +0x1d
...
```

**The Investigation**
Running the `vhs` background command (`ttyd -p 7654 powershell`) manually reveals that `ttyd` is crashing natively with:
`== CreateProcessW failed with error 267: The directory name is invalid.`

This is a known issue in `ttyd` (see tsl0922/ttyd#1292). In the Windows source code (`pty_spawn`), if a working directory isn't explicitly provided, the default directory resolution fails and passes a malformed string to `CreateProcessW` (see [the exact lines throwing the error](https://github.com/tsl0922/ttyd/blob/647d55ad865f5ad85ad89ba5e1b28d9b6ac8fd55/src/pty.c#L346-L356).

**Upstream Context & Fix**
This directory resolution bug seems to have been addressed upstream in `ttyd` PR tsl0922/ttyd#1502. However, **`ttyd` has not cut a new release in over 2 years**, meaning all `vhs` Windows users downloading the latest official binaries are still subjected to this crash.

By explicitly appending `-w .` to the `ttyd` arguments inside `tty.go` for Windows, we force `ttyd` to use the current native directory. This bypasses the upstream bug entirely and allows `vhs` to successfully spawn the process and record the tape.

### Steps to Reproduce (Before)

1. Ensure you have the latest release binary of `ttyd` (1.7.7) on Windows.
2. Run `vhs demo.tape`.
3. `vhs` panics with `use of closed network connection`.

### Steps to Reproduce (After)

1. Run `vhs demo.tape` on Windows.
2. `ttyd` successfully launches the shell using the explicit `-w .` flag.
3. The tape finishes recording and successfully outputs the GIF.