### PR TITLE
docs: fix broken window bar gif references in settings example

### DIFF
--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -134,10 +134,10 @@ Sleep 2s
 
 ### Window Bars
 
-<img width="600" src="./set-bar.gif">
+<img width="600" src="./set-window-bar.gif">
 
 ```
-Output "examples/settings/set-bar.gif"
+Output "examples/settings/set-window-bar.gif"
 Set FontSize 25
 Set Width 600
 Set Height 300


### PR DESCRIPTION
The **Window Bars** section of `examples/settings/README.md` references `set-bar.gif`:

- line 137: `<img width="600" src="./set-bar.gif">` (renders a broken image on GitHub)
- line 140: `Output "examples/settings/set-bar.gif"` in the tape snippet

That file does not exist. The committed asset is `set-window-bar.gif` (generated by `examples/settings/set-window-bar.tape`, whose `Output` is `examples/settings/set-window-bar.gif`), matching the "Window Bars" heading. This updates both references to `set-window-bar.gif`.
