### PR TITLE
feat: add opt-in sixel image capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,21 @@ Set the rate at which VHS captures frames with the `Set Framerate` command.
 Set Framerate 60
 ```
 
+#### Set Sixel
+
+Capture sixel images with `Set Sixel true`. Disabled by default because capturing
+the additional image layer increases CPU and disk usage and can reduce the
+achieved frame rate. Requires a ttyd build with sixel support.
+
+```elixir
+Set Sixel true
+```
+
+Images are included in videos, screenshots, and exported frame layers. See
+[`examples/sixel.tape`](./examples/sixel.tape) for a standalone example.
+
+![Sixel recording](./examples/sixel.gif)
+
 #### Set Playback Speed
 
 Set the playback speed of the final render.

--- a/command.go
+++ b/command.go
@@ -482,6 +482,7 @@ var Settings = map[string]CommandFunc{
 	"WaitPattern":   ExecuteSetWaitPattern,
 	"WaitTimeout":   ExecuteSetWaitTimeout,
 	"CursorBlink":   ExecuteSetCursorBlink,
+	"Sixel":         ExecuteSetSixel,
 }
 
 // ExecuteSet applies the settings on the running vhs specified by the
@@ -748,6 +749,17 @@ func ExecuteSetCursorBlink(c parser.Command, v *VHS) error {
 		return fmt.Errorf("failed to parse cursor blink: %w", err)
 	}
 
+	return nil
+}
+
+// ExecuteSetSixel enables capture of terminal images.
+func ExecuteSetSixel(c parser.Command, v *VHS) error {
+	enabled, err := strconv.ParseBool(c.Args)
+	if err != nil {
+		return fmt.Errorf("failed to parse sixel: %w", err)
+	}
+	v.Options.Video.Sixel = enabled
+	v.Options.Screenshot.sixel = enabled
 	return nil
 }
 

--- a/evaluator.go
+++ b/evaluator.go
@@ -111,8 +111,8 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 	}
 
 	// Begin recording frames as we are now in a recording state.
-	ctx, cancel := context.WithCancel(ctx)
-	ch := v.Record(ctx)
+	recordCtx, cancel := context.WithCancel(ctx)
+	ch := v.Record(recordCtx)
 
 	// Clean up temporary files at the end.
 	defer func() {

--- a/evaluator_integration_test.go
+++ b/evaluator_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	_ "image/gif"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Requires stock ttyd, Chrome or Chromium, and FFmpeg.
+func TestEvaluateCreatesMedia(t *testing.T) {
+	dir := t.TempDir()
+	tape := fmt.Sprintf(`Output "%s/out.gif"
+Set Shell bash
+Set Width 400
+Set Height 300
+Set Framerate 10
+Sleep 500ms
+Screenshot "%s/out.png"
+Sleep 500ms
+`, dir, dir)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if errs := Evaluate(ctx, tape, io.Discard); len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	for _, name := range []string{"out.gif", "out.png"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		requireNoErr(t, err)
+		_, _, err = image.Decode(bytes.NewReader(data))
+		requireNoErr(t, err)
+	}
+}

--- a/examples/sixel.gif
+++ b/examples/sixel.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccbea0021f648189b9b7987a15cd3f119526eb3583216da5267b9f37dfa0987a
+size 61546

--- a/examples/sixel.tape
+++ b/examples/sixel.tape
@@ -1,0 +1,29 @@
+# Run from the repository root: vhs examples/sixel.tape
+# Requires ttyd with sixel support; no image encoder is needed.
+Output examples/sixel.gif
+
+Set Shell bash
+Set Width 800
+Set Height 400
+Set FontSize 18
+Set Sixel true
+
+Hide
+Type "clear"
+Enter
+Show
+Sleep 500ms
+
+# A red 300x30 pixel block, followed by text.
+Type `printf '\033Pq#0;2;100;0;0#0!300~-!300~-!300~-!300~-!300~\033\\\n'; echo after`
+Enter
+Sleep 1s
+Screenshot examples/sixel.png
+
+# Remove the image, then create another to exercise canvas replacement.
+Type "clear"
+Enter
+Sleep 1s
+Type `printf '\033Pq#0;2;0;100;0#0!300~-!300~-!300~-!300~-!300~\033\\\n'; echo again`
+Enter
+Sleep 1s

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -22,12 +22,13 @@ func NewVideoFilterBuilder(videoOpts *VideoOptions) *FilterComplexBuilder {
 	termWidth, termHeight := calcTermDimensions(*videoOpts.Style)
 
 	_, _ = fmt.Fprintf(&filterCode, `
-		[0][1]overlay[merged];
+		%s;
 		[merged]scale=%d:%d:force_original_aspect_ratio=1[scaled];
 		[scaled]fps=%d,setpts=PTS/%f[speed];
 		[speed]pad=%d:%d:(ow-iw)/2:(oh-ih)/2:%s[padded];
 		[padded]fillborders=left=%d:right=%d:top=%d:bottom=%d:mode=fixed:color=%s[padded]
 		`,
+		terminalOverlay(videoOpts.Sixel),
 		termWidth-double(videoOpts.Style.Padding),
 		termHeight-double(videoOpts.Style.Padding),
 
@@ -55,16 +56,17 @@ func NewVideoFilterBuilder(videoOpts *VideoOptions) *FilterComplexBuilder {
 }
 
 // NewScreenshotFilterComplexBuilder returns instance of FilterComplexBuilder with screenshot config.
-func NewScreenshotFilterComplexBuilder(style *StyleOptions) *FilterComplexBuilder {
+func NewScreenshotFilterComplexBuilder(style *StyleOptions, sixel bool) *FilterComplexBuilder {
 	filterCode := strings.Builder{}
 	termWidth, termHeight := calcTermDimensions(*style)
 
 	_, _ = fmt.Fprintf(&filterCode, `
-		[0][1]overlay[merged];
+		%s;
 		[merged]scale=%d:%d:force_original_aspect_ratio=1[scaled];
 		[scaled]pad=%d:%d:(ow-iw)/2:(oh-ih)/2:%s[padded];
 		[padded]fillborders=left=%d:right=%d:top=%d:bottom=%d:mode=fixed:color=%s[padded]
 		`,
+		terminalOverlay(sixel),
 		termWidth-double(style.Padding),
 		termHeight-double(style.Padding),
 
@@ -86,6 +88,13 @@ func NewScreenshotFilterComplexBuilder(style *StyleOptions) *FilterComplexBuilde
 		style:         style,
 		prevStageName: "padded",
 	}
+}
+
+func terminalOverlay(sixel bool) string {
+	if sixel {
+		return "[0][2]overlay[withimg];[withimg][1]overlay[merged]"
+	}
+	return "[0][1]overlay[merged]"
 }
 
 // calcTermDimensions computes terminal dimensions.

--- a/man.go
+++ b/man.go
@@ -74,6 +74,7 @@ The following is a list of all possible setting commands in VHS:
 * Set %Theme% <json|string>
 * Set %Padding% <number>
 * Set %Framerate% <number>
+* Set %Sixel% <boolean> (default false; capture sixel images)
 * Set %PlaybackSpeed% <float>
 * Set %WaitTimeout% <time>
 * Set %WaitPattern% <regexp>

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -513,7 +513,7 @@ func (p *Parser) parseSet() Command {
 				)
 			}
 		}
-	case token.CURSOR_BLINK:
+	case token.CURSOR_BLINK, token.SIXEL:
 		cmd.Args = p.peek.Literal
 		p.nextToken()
 

--- a/screenshot.go
+++ b/screenshot.go
@@ -22,6 +22,7 @@ type ScreenshotOptions struct {
 	input string
 
 	style *StyleOptions
+	sixel bool
 }
 
 // NewScreenshotOptions returns ScreenshotOptions by given input.
@@ -57,8 +58,9 @@ func MakeScreenshots(ctx context.Context, opts ScreenshotOptions) []*exec.Cmd {
 	for path, frame := range opts.screenshots {
 		cursorStream := filepath.Join(opts.input, fmt.Sprintf(cursorFrameFormat, frame))
 		textStream := filepath.Join(opts.input, fmt.Sprintf(textFrameFormat, frame))
+		imageStream := filepath.Join(opts.input, fmt.Sprintf(imageFrameFormat, frame))
 
-		args := opts.buildFFopts(path, textStream, cursorStream)
+		args := opts.buildFFopts(path, textStream, cursorStream, imageStream)
 
 		cmds = append(cmds, exec.CommandContext(
 			ctx,
@@ -71,9 +73,12 @@ func MakeScreenshots(ctx context.Context, opts ScreenshotOptions) []*exec.Cmd {
 }
 
 // buildFFopts assembles an ffmpeg command from some VideoOptions.
-func (opts *ScreenshotOptions) buildFFopts(targetFile, textStream, cursorStream string) []string {
+func (opts *ScreenshotOptions) buildFFopts(targetFile, textStream, cursorStream, imageStream string) []string {
 	var args []string //nolint:prealloc
 	streamCounter := 2
+	if opts.sixel {
+		streamCounter++
+	}
 
 	streamBuilder := NewStreamBuilder(streamCounter, opts.input, opts.style)
 	// Input frame options, used no matter what
@@ -84,13 +89,16 @@ func (opts *ScreenshotOptions) buildFFopts(targetFile, textStream, cursorStream 
 		"-i", textStream,
 		"-i", cursorStream,
 	)
+	if opts.sixel {
+		streamBuilder.args = append(streamBuilder.args, "-i", imageStream)
+	}
 
 	streamBuilder = streamBuilder.
 		WithMargin().
 		WithBar().
 		WithCorner()
 
-	filterBuilder := NewScreenshotFilterComplexBuilder(opts.style).
+	filterBuilder := NewScreenshotFilterComplexBuilder(opts.style, opts.sixel).
 		WithWindowBar(streamBuilder.barStream).
 		WithBorderRadius(streamBuilder.cornerStream).
 		WithMarginFill(streamBuilder.marginStream)

--- a/sixel.go
+++ b/sixel.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/png"
+
+	"github.com/go-rod/rod"
+)
+
+// The image addon creates and removes its canvas as images enter and leave the
+// screen. Query and read it in one evaluation so no detached element is retained.
+// Image canvases may use CSS pixels while the text canvas uses device pixels.
+const captureImageLayer = `() => {
+	const text = document.querySelector('canvas.xterm-text-layer');
+	const width = text.width, height = text.height;
+	let image = document.querySelector('canvas.xterm-image-layer');
+	if (!image || !image.width || !image.height) return {width, height, data: ''};
+	if (image.width !== width || image.height !== height) {
+		const scaled = document.createElement('canvas');
+		scaled.width = width;
+		scaled.height = height;
+		scaled.getContext('2d').drawImage(image, 0, 0, width, height);
+		image = scaled;
+	}
+	return {width, height, data: image.toDataURL('image/png').split(',')[1]};
+}`
+
+type imageLayerCapture struct {
+	width, height int
+	transparent   []byte
+}
+
+func (c *imageLayerCapture) capture(page *rod.Page) ([]byte, error) {
+	result, err := page.Eval(captureImageLayer)
+	if err != nil {
+		return nil, fmt.Errorf("capture image layer: %w", err)
+	}
+	if data := result.Value.Get("data").Str(); data != "" {
+		frame, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			return nil, fmt.Errorf("decode image layer: %w", err)
+		}
+		return frame, nil
+	}
+	width := result.Value.Get("width").Int()
+	height := result.Value.Get("height").Int()
+	if width <= 0 || height <= 0 {
+		return nil, fmt.Errorf("invalid image frame dimensions: %dx%d", width, height)
+	}
+	if c.transparent == nil || c.width != width || c.height != height {
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, image.NewNRGBA(image.Rect(0, 0, width, height))); err != nil {
+			return nil, fmt.Errorf("encode transparent image frame: %w", err)
+		}
+		c.width, c.height = width, height
+		c.transparent = buf.Bytes()
+	}
+	return c.transparent, nil
+}

--- a/sixel_benchmark_test.go
+++ b/sixel_benchmark_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+// Run with go test -tags integration -run '^$' -bench BenchmarkSixelCapture -benchtime=3s.
+// Reports throughput of canvas readback and PNG writes, without the frame timer.
+func BenchmarkSixelCapture(b *testing.B) {
+	for _, mode := range []string{"disabled", "blank", "image"} {
+		b.Run(mode, func(b *testing.B) {
+			v := New()
+			b.Cleanup(func() { _ = v.Cleanup() })
+			v.Options.Video.Style.Width = 1200
+			v.Options.Video.Style.Height = 700
+			v.Options.Video.Style.Padding = 20
+			v.Options.Video.Sixel = mode != "disabled"
+			if err := v.Start(context.Background()); err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(func() { _ = v.terminate() })
+			if err := v.Page.Wait(rod.Eval("() => window.term !== undefined")); err != nil {
+				b.Fatal(err)
+			}
+			v.Setup()
+			if mode == "image" {
+				v.Page.MustEval(`() => new Promise(resolve => term.write('\x1bPq#0;2;100;0;0#0!300~-!300~-!300~-!300~-!300~\x1b\\', resolve))`)
+				v.Page.Timeout(5 * time.Second).MustWait(`() => !!document.querySelector('canvas.xterm-image-layer')`)
+			}
+			var images imageLayerCapture
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cursor, err := v.CursorCanvas.CanvasToImage("image/png", quality)
+				if err != nil {
+					b.Fatal(err)
+				}
+				text, err := v.TextCanvas.CanvasToImage("image/png", quality)
+				if err != nil {
+					b.Fatal(err)
+				}
+				frames := [][]byte{text, cursor}
+				if mode != "disabled" {
+					img, err := images.capture(v.Page)
+					if err != nil {
+						b.Fatal(err)
+					}
+					frames = append(frames, img)
+				}
+				for layer, frame := range frames {
+					if err := os.WriteFile(filepath.Join(v.Options.Video.Input, fmt.Sprintf("layer-%d.png", layer)), frame, 0o600); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "frames/s")
+		})
+	}
+}
+
+// Measure the recorder with its actual 60 fps timer and per-frame file names.
+func TestSixelCaptureRate(t *testing.T) {
+	if os.Getenv("VHS_MEASURE_CAPTURE") == "" {
+		t.Skip("set VHS_MEASURE_CAPTURE=1 for capture-rate measurements")
+	}
+	for _, mode := range []string{"disabled", "blank", "image"} {
+		t.Run(mode, func(t *testing.T) {
+			v := New()
+			t.Cleanup(func() { _ = v.Cleanup() })
+			v.Options.Video.Style.Width = 1200
+			v.Options.Video.Style.Height = 700
+			v.Options.Video.Style.Padding = 20
+			v.Options.Video.Framerate = 60
+			v.Options.Video.Sixel = mode != "disabled"
+			requireNoErr(t, v.Start(context.Background()))
+			requireNoErr(t, v.Page.Wait(rod.Eval("() => window.term !== undefined")))
+			v.Setup()
+			if mode == "image" {
+				v.Page.MustEval(`() => new Promise(resolve => term.write('\x1bPq#0;2;100;0;0#0!300~-!300~-!300~-!300~-!300~\x1b\\', resolve))`)
+				v.Page.Timeout(5 * time.Second).MustWait(`() => !!document.querySelector('canvas.xterm-image-layer')`)
+			}
+			const duration = 3 * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), duration)
+			defer cancel()
+			for err := range v.Record(ctx) {
+				t.Error(err)
+			}
+			t.Logf("1200x700, requested 60 fps: %d frames in %s, %.1f fps", v.totalFrames, duration, float64(v.totalFrames)/duration.Seconds())
+		})
+	}
+}

--- a/sixel_integration_test.go
+++ b/sixel_integration_test.go
@@ -1,0 +1,275 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	imagegif "image/gif"
+	"image/png"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+)
+
+func TestSixelRecording(t *testing.T) {
+	dir := t.TempDir()
+	// The image arrives after recording starts, leaves, then returns in green.
+	tape := fmt.Sprintf(`Output "%s/frames/"
+Output "%s/out.gif"
+Set Shell bash
+Set Width 800
+Set Height 400
+Set FontSize 18
+Set Framerate 24
+Set Sixel true
+Set LoopOffset 50%%
+Hide
+Type "clear"
+Enter
+Show
+Sleep 300ms
+Screenshot "%s/blank.png"
+Sleep 300ms
+Hide
+Type `+"`"+`printf '\033Pq#0;2;100;0;0#0!300~-!300~-!300~-!300~-!300~\033\\\n'`+"`"+`
+Enter
+Show
+Sleep 300ms
+Screenshot "%s/red.png"
+Sleep 300ms
+Hide
+Type "clear"
+Enter
+Show
+Sleep 300ms
+Screenshot "%s/cleared.png"
+Sleep 300ms
+Hide
+Type `+"`"+`printf '\033Pq#0;2;0;100;0#0!300~-!300~-!300~-!300~-!300~\033\\\n'`+"`"+`
+Enter
+Show
+Sleep 300ms
+Screenshot "%s/green.png"
+Sleep 300ms
+`, dir, dir, dir, dir, dir, dir)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if errs := Evaluate(ctx, tape, io.Discard); len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	for _, name := range []string{"blank", "red", "cleared", "green"} {
+		data, err := os.ReadFile(filepath.Join(dir, name+".png"))
+		requireNoErr(t, err)
+		img, err := png.Decode(bytes.NewReader(data))
+		requireNoErr(t, err)
+		var red, green int
+		for y := 0; y < img.Bounds().Dy(); y++ {
+			for x := 0; x < img.Bounds().Dx(); x++ {
+				c := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
+				if c.R > 220 && c.G < 30 && c.B < 30 {
+					red++
+				}
+				if c.G > 220 && c.R < 30 && c.B < 30 {
+					green++
+				}
+			}
+		}
+		if (name == "red") != (red > 8000) || (name == "green") != (green > 8000) {
+			t.Fatalf("%s: red pixels=%d, green pixels=%d", name, red, green)
+		}
+	}
+	frames, err := filepath.Glob(filepath.Join(dir, "frames", "frame-text-*.png"))
+	requireNoErr(t, err)
+	if len(frames) == 0 {
+		t.Fatal("no exported frames")
+	}
+	for _, frame := range frames {
+		for _, layer := range []string{"cursor", "image"} {
+			_, err := os.Stat(strings.Replace(frame, "frame-text-", "frame-"+layer+"-", 1))
+			requireNoErr(t, err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "out.gif"))
+	requireNoErr(t, err)
+	_, err = imagegif.DecodeAll(bytes.NewReader(data))
+	requireNoErr(t, err)
+}
+
+// Run with go test -tags integration; requires a local Chrome and FFmpeg.
+func TestImageLayerLifecycle(t *testing.T) {
+	bin, found := launcher.LookPath()
+	if !found {
+		t.Fatal("integration test requires Chrome or Chromium")
+	}
+	u := launcher.New().Bin(bin).Leakless(false).NoSandbox(os.Getenv("VHS_NO_SANDBOX") != "").MustLaunch()
+	browser := rod.New().ControlURL(u).MustConnect()
+	t.Cleanup(func() { browser.MustClose() })
+	page := browser.MustPage().Timeout(15 * time.Second)
+	page.MustEval(`() => {
+		const text = document.createElement('canvas');
+		text.className = 'xterm-text-layer'; text.width = 40; text.height = 20;
+		document.body.appendChild(text);
+	}`)
+	var capture imageLayerCapture
+	check := func(want color.NRGBA, width, height int) {
+		t.Helper()
+		data, err := capture.capture(page)
+		requireNoErr(t, err)
+		img, err := png.Decode(bytes.NewReader(data))
+		requireNoErr(t, err)
+		if img.Bounds() != image.Rect(0, 0, width, height) {
+			t.Fatalf("incorrect dimensions: %v", img.Bounds())
+		}
+		if got := color.NRGBAModel.Convert(img.At(width/2, height/2)).(color.NRGBA); got != want {
+			t.Fatalf("pixel: %v; want %v", got, want)
+		}
+	}
+	check(color.NRGBA{}, 40, 20)
+	page.MustEval(`() => {
+		const img = document.createElement('canvas');
+		img.className = 'xterm-image-layer'; img.width = 20; img.height = 10;
+		document.body.appendChild(img);
+		const ctx = img.getContext('2d', {alpha: true, desynchronized: true});
+		ctx.fillStyle = '#ff0000'; ctx.fillRect(0, 0, 20, 10);
+	}`)
+	check(color.NRGBA{R: 255, A: 255}, 40, 20)
+	page.MustEval(`() => document.querySelector('.xterm-image-layer').remove()`)
+	check(color.NRGBA{}, 40, 20)
+	page.MustEval(`() => {
+		const img = document.createElement('canvas');
+		img.className = 'xterm-image-layer'; img.width = 40; img.height = 20;
+		document.body.appendChild(img);
+	}`)
+	check(color.NRGBA{}, 40, 20)
+	page.MustEval(`() => {
+		const ctx = document.querySelector('.xterm-image-layer').getContext('2d');
+		ctx.fillStyle = '#00ff00'; ctx.fillRect(0, 0, 40, 20);
+	}`)
+	check(color.NRGBA{G: 255, A: 255}, 40, 20)
+	page.MustEval(`() => document.querySelector('.xterm-image-layer').width = 0`)
+	check(color.NRGBA{}, 40, 20)
+	page.MustEval(`() => document.querySelector('.xterm-text-layer').width = 80`)
+	check(color.NRGBA{}, 80, 20)
+	page.MustEval(`() => document.querySelector('.xterm-text-layer').remove()`)
+	_, err := capture.capture(page)
+	requireErr(t, err)
+}
+
+func TestSixelFFmpegPixels(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Fatal("integration test requires FFmpeg")
+	}
+	for _, enabled := range []bool{false, true} {
+		for _, decorated := range []bool{false, true} {
+			t.Run(fmt.Sprintf("sixel=%t/decorated=%t", enabled, decorated), func(t *testing.T) {
+				dir := t.TempDir()
+				style := &StyleOptions{Width: 80, Height: 60, Padding: 2, BackgroundColor: "#000000"}
+				x, y := 2, 2
+				if decorated {
+					style.Margin = 10
+					style.MarginFill = "#000000"
+					style.WindowBar = "Colorful"
+					style.WindowBarSize = 30
+					style.WindowBarColor = "#000000"
+					style.BorderRadius = 4
+					style.Width += 20
+					style.Height += 50
+					x += 10
+					y += 40
+				}
+				// Leave a trailing frame for the fps filter's end-of-stream rounding.
+				for frame := 1; frame <= 3; frame++ {
+					for _, format := range []string{textFrameFormat, cursorFrameFormat, imageFrameFormat} {
+						img := image.NewNRGBA(image.Rect(0, 0, 76, 56))
+						switch format {
+						case textFrameFormat:
+							draw.Draw(img, img.Bounds(), image.NewUniform(color.NRGBA{B: 255, A: 255}), image.Point{}, draw.Src)
+						case cursorFrameFormat:
+							draw.Draw(img, image.Rect(30, 20, 40, 30), image.NewUniform(color.NRGBA{G: 255, A: 255}), image.Point{}, draw.Src)
+						case imageFrameFormat:
+							if frame == 1 {
+								draw.Draw(img, image.Rect(10, 10, 50, 40), image.NewUniform(color.NRGBA{R: 255, A: 255}), image.Point{}, draw.Src)
+							}
+						}
+						var buf bytes.Buffer
+						requireNoErr(t, png.Encode(&buf, img))
+						requireNoErr(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf(format, frame)), buf.Bytes(), 0o600))
+					}
+				}
+				check := func(img image.Image, frame int) {
+					t.Helper()
+					if img.Bounds().Dx() != style.Width || img.Bounds().Dy() != style.Height {
+						t.Fatalf("output size: %v", img.Bounds())
+					}
+					wantImage := color.NRGBA{B: 255, A: 255}
+					if enabled && frame == 1 {
+						wantImage = color.NRGBA{R: 255, A: 255}
+					}
+					for _, p := range []struct {
+						x, y int
+						want color.NRGBA
+					}{
+						{5, 5, color.NRGBA{B: 255, A: 255}},
+						{20, 20, wantImage},
+						{35, 25, color.NRGBA{G: 255, A: 255}},
+					} {
+						got := color.NRGBAModel.Convert(img.At(x+p.x, y+p.y)).(color.NRGBA)
+						// FFmpeg's overlay filter converts through YUV by default.
+						for channel, value := range []uint8{got.R, got.G, got.B, got.A} {
+							want := []uint8{p.want.R, p.want.G, p.want.B, p.want.A}[channel]
+							if diff := int(value) - int(want); diff < -5 || diff > 5 {
+								t.Fatalf("frame %d pixel (%d,%d): %v; want approximately %v", frame, p.x, p.y, got, p.want)
+							}
+						}
+					}
+				}
+				run := func(args []string) {
+					t.Helper()
+					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+					if out, err := exec.CommandContext(ctx, "ffmpeg", args...).CombinedOutput(); err != nil {
+						t.Fatalf("ffmpeg: %v\n%s", err, out)
+					}
+				}
+				shot := NewScreenshotOptions(dir, style)
+				shot.sixel = enabled
+				for frame := 1; frame <= 2; frame++ {
+					path := filepath.Join(dir, "out.png")
+					run(shot.buildFFopts(path, filepath.Join(dir, fmt.Sprintf(textFrameFormat, frame)), filepath.Join(dir, fmt.Sprintf(cursorFrameFormat, frame)), filepath.Join(dir, fmt.Sprintf(imageFrameFormat, frame))))
+					data, err := os.ReadFile(path)
+					requireNoErr(t, err)
+					img, err := png.Decode(bytes.NewReader(data))
+					requireNoErr(t, err)
+					check(img, frame)
+				}
+				path := filepath.Join(dir, "out.gif")
+				run(buildFFopts(VideoOptions{Input: dir, Style: style, Framerate: 25, StartingFrame: 1, PlaybackSpeed: 1, Sixel: enabled}, path))
+				data, err := os.ReadFile(path)
+				requireNoErr(t, err)
+				animation, err := imagegif.DecodeAll(bytes.NewReader(data))
+				requireNoErr(t, err)
+				if len(animation.Image) < 2 {
+					t.Fatal("expected both video frames")
+				}
+				// GIF encoders may store only changed rectangles in later frames.
+				composite := image.NewNRGBA(image.Rect(0, 0, style.Width, style.Height))
+				for i, frame := range animation.Image {
+					draw.Draw(composite, frame.Bounds(), frame, frame.Bounds().Min, draw.Over)
+					check(composite, i+1)
+				}
+			})
+		}
+	}
+}

--- a/sixel_test.go
+++ b/sixel_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/vhs/lexer"
+	"github.com/charmbracelet/vhs/parser"
+)
+
+func TestSixelSetting(t *testing.T) {
+	v := VHS{Options: &Options{}}
+	if v.Options.Video.Sixel || v.Options.Screenshot.sixel {
+		t.Fatal("sixel must default to disabled")
+	}
+	for _, value := range []string{"true", "false"} {
+		p := parser.New(lexer.New("Set Sixel " + value))
+		commands := p.Parse()
+		if len(p.Errors()) != 0 || len(commands) != 1 {
+			t.Fatalf("parse %s: %v", value, p.Errors())
+		}
+		requireNoErr(t, Execute(commands[0], &v))
+		if v.Options.Video.Sixel != (value == "true") || v.Options.Screenshot.sixel != (value == "true") {
+			t.Fatalf("setting %s not applied to both outputs", value)
+		}
+	}
+	for _, value := range []string{"Enabled", "1", ""} {
+		p := parser.New(lexer.New("Set Sixel " + value))
+		p.Parse()
+		if len(p.Errors()) == 0 {
+			t.Fatalf("accepted invalid boolean %q", value)
+		}
+	}
+}
+
+func TestSixelInputs(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprint(enabled), func(t *testing.T) {
+			dir := t.TempDir()
+			style := DefaultStyleOptions()
+			style.WindowBar = "Colorful"
+			style.BorderRadius = 8
+			opts := VideoOptions{Input: dir, Style: style, Framerate: 60, StartingFrame: 7, PlaybackSpeed: 1, Sixel: enabled}
+			shot := NewScreenshotOptions(dir, style)
+			shot.sixel = enabled
+			for _, args := range [][]string{
+				buildFFopts(opts, "out.gif"),
+				shot.buildFFopts("out.png", filepath.Join(dir, textFrameFormat), filepath.Join(dir, cursorFrameFormat), filepath.Join(dir, imageFrameFormat)),
+			} {
+				var inputs []string
+				var filter string
+				for i, arg := range args {
+					if arg == "-i" {
+						inputs = append(inputs, args[i+1])
+					}
+					if arg == "-filter_complex" {
+						filter = args[i+1]
+					}
+				}
+				want := []string{filepath.Join(dir, textFrameFormat), filepath.Join(dir, cursorFrameFormat)}
+				margin := 2
+				if enabled {
+					want = append(want, filepath.Join(dir, imageFrameFormat))
+					margin++
+					if !strings.Contains(filter, "[0][2]overlay[withimg];[withimg][1]overlay[merged]") {
+						t.Fatalf("incorrect image overlay: %s", filter)
+					}
+				} else if !strings.Contains(filter, "[0][1]overlay[merged]") || strings.Contains(filter, "withimg") {
+					t.Fatalf("default overlay changed: %s", filter)
+				}
+				want = append(want, "color="+style.MarginFill+":s=1200x600", filepath.Join(dir, "bar.png"), filepath.Join(dir, "mask.png"))
+				if !reflect.DeepEqual(inputs, want) {
+					t.Fatalf("inputs: %v; want %v", inputs, want)
+				}
+				for _, stage := range []string{fmt.Sprintf("[%d]scale=", margin), fmt.Sprintf("[%d]loop=", margin+1), fmt.Sprintf("[%d]", margin+2)} {
+					if !strings.Contains(filter, stage) {
+						t.Fatalf("missing decoration %s in %s", stage, filter)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSixelLoopOffset(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprint(enabled), func(t *testing.T) {
+			dir := t.TempDir()
+			formats := []string{textFrameFormat, cursorFrameFormat}
+			if enabled {
+				formats = append(formats, imageFrameFormat)
+			}
+			for frame := 1; frame <= 4; frame++ {
+				for _, format := range formats {
+					name := fmt.Sprintf(format, frame)
+					requireNoErr(t, os.WriteFile(filepath.Join(dir, name), []byte(name), 0o600))
+				}
+			}
+			v := VHS{totalFrames: 4, Options: &Options{
+				LoopOffset: 50,
+				Video:      VideoOptions{Input: dir, StartingFrame: 1, Sixel: enabled},
+				Screenshot: ScreenshotOptions{
+					input: dir, style: DefaultStyleOptions(), sixel: enabled,
+					screenshots: map[string]int{"early.png": 1, "late.png": 4},
+				},
+			}}
+			requireNoErr(t, v.ApplyLoopOffset())
+			if v.Options.Video.StartingFrame != 3 || v.Options.Screenshot.screenshots["early.png"] != 5 || v.Options.Screenshot.screenshots["late.png"] != 4 {
+				t.Fatal("incorrect frame references after loop offset")
+			}
+			for index, original := range []int{3, 4, 1, 2} {
+				for _, format := range formats {
+					data, err := os.ReadFile(filepath.Join(dir, fmt.Sprintf(format, index+3)))
+					requireNoErr(t, err)
+					if string(data) != fmt.Sprintf(format, original) {
+						t.Fatalf("incorrect frame: %s", data)
+					}
+				}
+			}
+			for _, cmd := range MakeScreenshots(context.Background(), v.Options.Screenshot) {
+				for i, arg := range cmd.Args {
+					if arg == "-i" && strings.Contains(cmd.Args[i+1], "frame-") {
+						_, err := os.Stat(cmd.Args[i+1])
+						requireNoErr(t, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -107,6 +107,7 @@ const (
 	WAIT_TIMEOUT    = "WAIT_TIMEOUT"
 	WAIT_PATTERN    = "WAIT_PATTERN"
 	CURSOR_BLINK    = "CURSOR_BLINK"
+	SIXEL           = "SIXEL"
 )
 
 // Keywords maps keyword strings to tokens.
@@ -165,6 +166,7 @@ var Keywords = map[string]Type{
 	"Wait":          WAIT,
 	"Source":        SOURCE,
 	"CursorBlink":   CURSOR_BLINK,
+	"Sixel":         SIXEL,
 	"true":          BOOLEAN,
 	"false":         BOOLEAN,
 	"Screenshot":    SCREENSHOT,
@@ -179,7 +181,7 @@ func IsSetting(t Type) bool {
 	case SHELL, FONT_FAMILY, FONT_SIZE, LETTER_SPACING, LINE_HEIGHT,
 		FRAMERATE, TYPING_SPEED, THEME, PLAYBACK_SPEED, HEIGHT, WIDTH,
 		PADDING, LOOP_OFFSET, MARGIN_FILL, MARGIN, WINDOW_BAR,
-		WINDOW_BAR_SIZE, BORDER_RADIUS, CURSOR_BLINK, WAIT_TIMEOUT, WAIT_PATTERN:
+		WINDOW_BAR_SIZE, BORDER_RADIUS, CURSOR_BLINK, SIXEL, WAIT_TIMEOUT, WAIT_PATTERN:
 		return true
 	default:
 		return false

--- a/vhs.go
+++ b/vhs.go
@@ -272,49 +272,40 @@ func (vhs *VHS) ApplyLoopOffset() error {
 	// New starting frame will be the next frame after offsetEnd
 	vhs.Options.Video.StartingFrame = offsetEnd + 1
 
-	// Rename all text and cursor frame files in the range concurrently
-	errCh := make(chan error)
-	doneCh := make(chan bool)
-	var wg sync.WaitGroup
-
-	for counter := offsetStart; counter <= offsetEnd; counter++ {
-		wg.Add(1)
-		go func(frameNum int) {
-			defer wg.Done()
-			offsetFrameNum := frameNum + vhs.totalFrames
-			if err := os.Rename(
-				filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(cursorFrameFormat, frameNum)),
-				filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(cursorFrameFormat, offsetFrameNum)),
-			); err != nil {
-				errCh <- fmt.Errorf("error applying offset to cursor frame: %w", err)
-			}
-		}(counter)
-
-		wg.Add(1)
-		go func(frameNum int) {
-			defer wg.Done()
-			offsetFrameNum := frameNum + vhs.totalFrames
-			if err := os.Rename(
-				filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(textFrameFormat, frameNum)),
-				filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(textFrameFormat, offsetFrameNum)),
-			); err != nil {
-				errCh <- fmt.Errorf("error applying offset to text frame: %w", err)
-			}
-		}(counter)
+	// Rename each frame's layers together, retaining every stream's numbering.
+	formats := []string{textFrameFormat, cursorFrameFormat}
+	if vhs.Options.Video.Sixel {
+		formats = append(formats, imageFrameFormat)
 	}
-
-	go func() {
-		wg.Wait()
-		close(doneCh)
-	}()
-
-	select {
-	case <-doneCh:
-		return nil
-	case err := <-errCh:
-		// Bail out in case of an error while renaming
+	errCh := make(chan error, offsetEnd-offsetStart+1)
+	var wg sync.WaitGroup
+	for frame := offsetStart; frame <= offsetEnd; frame++ {
+		wg.Add(1)
+		go func(frame int) {
+			defer wg.Done()
+			for _, format := range formats {
+				if err := os.Rename(
+					filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(format, frame)),
+					filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(format, frame+vhs.totalFrames)),
+				); err != nil {
+					errCh <- fmt.Errorf("error applying offset to %s: %w", format, err)
+					return
+				}
+			}
+		}(frame)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
 		return err
 	}
+
+	for path, frame := range vhs.Options.Screenshot.screenshots {
+		if frame >= offsetStart && frame <= offsetEnd {
+			vhs.Options.Screenshot.screenshots[path] = frame + vhs.totalFrames
+		}
+	}
+	return nil
 }
 
 const quality = 1.0
@@ -327,6 +318,7 @@ func (vhs *VHS) Record(ctx context.Context) <-chan error {
 	//nolint: mnd
 	go func() {
 		counter := 0
+		var images imageLayerCapture
 		start := time.Now()
 		for {
 			select {
@@ -357,6 +349,15 @@ func (vhs *VHS) Record(ctx context.Context) <-chan error {
 					ch <- fmt.Errorf("error: %v, %v", textErr, cursorErr)
 					continue
 				}
+				var image []byte
+				if vhs.Options.Video.Sixel {
+					var err error
+					image, err = images.capture(vhs.Page)
+					if err != nil {
+						ch <- err
+						continue
+					}
+				}
 
 				counter++
 				if err := os.WriteFile(
@@ -374,6 +375,17 @@ func (vhs *VHS) Record(ctx context.Context) <-chan error {
 				); err != nil {
 					ch <- fmt.Errorf("error writing text frame: %w", err)
 					continue
+				}
+
+				if vhs.Options.Video.Sixel {
+					if err := os.WriteFile(
+						filepath.Join(vhs.Options.Video.Input, fmt.Sprintf(imageFrameFormat, counter)),
+						image,
+						0o600,
+					); err != nil {
+						ch <- fmt.Errorf("error writing image frame: %w", err)
+						continue
+					}
 				}
 
 				// Capture current frame and disable frame capturing

--- a/video.go
+++ b/video.go
@@ -21,6 +21,7 @@ import (
 const (
 	textFrameFormat   = "frame-text-%05d.png"
 	cursorFrameFormat = "frame-cursor-%05d.png"
+	imageFrameFormat  = "frame-image-%05d.png"
 )
 
 const (
@@ -57,6 +58,7 @@ type VideoOptions struct {
 	Output        VideoOutputs
 	StartingFrame int
 	Style         *StyleOptions
+	Sixel         bool
 }
 
 const (
@@ -111,6 +113,9 @@ func ensureDir(output string) {
 func buildFFopts(opts VideoOptions, targetFile string) []string {
 	var args []string //nolint:prealloc
 	streamCounter := 2
+	if opts.Sixel {
+		streamCounter++
+	}
 
 	streamBuilder := NewStreamBuilder(streamCounter, opts.Input, opts.Style)
 
@@ -126,6 +131,13 @@ func buildFFopts(opts VideoOptions, targetFile string) []string {
 		"-start_number", fmt.Sprint(opts.StartingFrame),
 		"-i", filepath.Join(opts.Input, cursorFrameFormat),
 	)
+	if opts.Sixel {
+		streamBuilder.args = append(streamBuilder.args,
+			"-r", fmt.Sprint(opts.Framerate),
+			"-start_number", fmt.Sprint(opts.StartingFrame),
+			"-i", filepath.Join(opts.Input, imageFrameFormat),
+		)
+	}
 
 	streamBuilder = streamBuilder.
 		WithMargin().


### PR DESCRIPTION
VHS enables sixel in ttyd but omits the image canvas when capturing frames. `Set Sixel true` now captures that layer and includes it in videos, screenshots, and exported frames. It defaults to false, following the performance concern in https://github.com/charmbracelet/vhs/issues/43#issuecomment-1301133323.

The addon creates and removes its canvas as images enter and leave the screen. Capture queries and reads the current canvas in one browser evaluation, writes transparent frames when it is absent, and scales image pixels to the text canvas dimensions when needed. FFmpeg overlays text, image, then cursor. Loop offsets move all layers and update screenshot references.

The first commit fixes a prerequisite regression: `Evaluate` canceled its recording context before passing it to FFmpeg, producing no output files. Recording now uses a child context while rendering retains the parent. The new end-to-end output test failed before that fix and passes with it.

Related to #43; completes the image-capture step described in #137.

### Standalone example

Run `vhs examples/sixel.tape` from the repository root. The tape emits sixel using shell `printf`; it needs no image encoder or ttyd fork.

![Sixel capture](https://github.com/jchook/vhs/blob/fix/sixel-recording/examples/sixel.gif?raw=true)
