### PR TITLE
fix: preserve context for rendering and report encoder errors

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -113,8 +113,8 @@ func Evaluate(ctx context.Context, tape string, out io.Writer, opts ...Evaluator
 	}
 
 	// Begin recording frames as we are now in a recording state.
-	ctx, cancel := context.WithCancel(ctx)
-	ch := v.Record(ctx)
+	recordCtx, cancel := context.WithCancel(ctx)
+	ch := v.Record(recordCtx)
 
 	// Clean up temporary files at the end.
 	defer func() {

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	imagegif "image/gif"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRenderMissingFFmpeg(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	v := New()
+	v.totalFrames = 1
+	t.Cleanup(func() { _ = v.Cleanup() })
+	v.Options.Video.Output.GIF = filepath.Join(t.TempDir(), "output.gif")
+
+	if err := v.Render(context.Background()); !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("expected missing ffmpeg error, got %v", err)
+	}
+}
+
+func TestEvaluateGIF(t *testing.T) {
+	if os.Getenv("VHS_TEST_BROWSER") == "" {
+		t.Skip("set VHS_TEST_BROWSER=1 to run this test")
+	}
+	for _, name := range []string{"ttyd", "ffmpeg"} {
+		if _, err := exec.LookPath(name); err != nil {
+			t.Fatalf("%s is required: %v", name, err)
+		}
+	}
+
+	for _, cancelRender := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cancel_render=%t", cancelRender), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			output := filepath.Join(t.TempDir(), "output.gif")
+			tape := fmt.Sprintf("Output %q\nSet Shell bash\nSet Width 320\nSet Height 200\nType hello\nSleep 500ms\n", filepath.ToSlash(output))
+			errs := Evaluate(ctx, tape, io.Discard, func(_ *VHS) {
+				if cancelRender {
+					cancel()
+				}
+			})
+			if cancelRender {
+				if len(errs) != 1 || !errors.Is(errs[0], context.Canceled) {
+					t.Fatalf("expected cancellation error, got %v", errs)
+				}
+				return
+			}
+			if len(errs) != 0 {
+				t.Fatalf("Evaluate failed: %v", errs)
+			}
+			file, err := os.Open(output)
+			if err != nil {
+				t.Fatalf("output was not created: %v", err)
+			}
+			defer file.Close()
+			if _, err := imagegif.DecodeAll(file); err != nil {
+				t.Fatalf("output is not a valid GIF: %v", err)
+			}
+		})
+	}
+}

--- a/vhs.go
+++ b/vhs.go
@@ -568,6 +568,7 @@ func (vhs *VHS) Render(ctx context.Context) error {
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Println(string(out))
+			return fmt.Errorf("render failed: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes #787.

Recording teardown canceled the context subsequently passed to ffmpeg, so completed tapes could exit successfully without creating their output. Keep recording cancellation on a child context and use the caller's context for rendering. Return encoder errors instead of only logging their output, so a missing ffmpeg executable or a failed render reaches the caller.

Added a regression test for missing ffmpeg and an opt-in browser test that records a short tape, decodes the resulting GIF, and checks cancellation immediately before rendering. All three cases failed on the original code and pass with the fix.

Validation on macOS arm64:
- `go test -race ./...`
- `go vet ./...`
- `VHS_TEST_BROWSER=1 go test -run 'Test(RenderMissingFFmpeg|EvaluateGIF)$' -count=1 -v .` (real Chrome, ttyd and ffmpeg)

Implemented with OpenAI Codex assistance and independently reviewed with Codex before submission.
